### PR TITLE
Complete Iteration 1: SHA-256 hashing and duplicate detection

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -460,6 +460,7 @@ class _FileStewardHomePageState extends State<FileStewardHomePage> {
 
   Widget _buildSummaryCard(ManifestResult result) {
     final int totalEntries = result.entries.length;
+    final int duplicateGroupCount = result.duplicateGroups.length;
 
     return Card(
       child: Padding(
@@ -475,9 +476,72 @@ class _FileStewardHomePageState extends State<FileStewardHomePage> {
               value: result.totalDirectories.toString(),
             ),
             _SummaryItem(label: 'Files', value: result.totalFiles.toString()),
+            _SummaryItem(
+              label: 'Dup. Groups',
+              value: duplicateGroupCount.toString(),
+            ),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildDuplicateGroups(ManifestResult result) {
+    if (result.duplicateGroups.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        const SizedBox(height: 16),
+        Text(
+          'Duplicate Groups (${result.duplicateGroups.length})',
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        ...result.duplicateGroups.asMap().entries.map((entry) {
+          final int index = entry.key;
+          final List<String> group = entry.value;
+          return Card(
+            margin: const EdgeInsets.only(bottom: 8),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    'Group ${index + 1} — ${group.length} identical files',
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 4),
+                  ...group.map(
+                    (path) => Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: Row(
+                        children: <Widget>[
+                          const Icon(
+                            Icons.content_copy,
+                            size: 14,
+                            color: Colors.orange,
+                          ),
+                          const SizedBox(width: 6),
+                          Expanded(
+                            child: Text(
+                              path,
+                              style: const TextStyle(fontSize: 13),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }),
+      ],
     );
   }
 
@@ -626,6 +690,7 @@ class _FileStewardHomePageState extends State<FileStewardHomePage> {
         )
       else
         ...visibleEntries.map(_buildManifestTile),
+      _buildDuplicateGroups(manifestResult),
     ];
   }
 

--- a/lib/manifest_models.dart
+++ b/lib/manifest_models.dart
@@ -2,11 +2,13 @@ class ManifestEntry {
   final String relativePath;
   final String entryType;
   final int? sizeBytes;
+  final String? sha256;
 
   ManifestEntry({
     required this.relativePath,
     required this.entryType,
     required this.sizeBytes,
+    this.sha256,
   });
 
   factory ManifestEntry.fromJson(Map<String, dynamic> json) {
@@ -14,6 +16,7 @@ class ManifestEntry {
       relativePath: json['relative_path'] as String? ?? '',
       entryType: json['entry_type'] as String? ?? 'other',
       sizeBytes: json['size_bytes'] as int?,
+      sha256: json['sha256'] as String?,
     );
   }
 
@@ -39,6 +42,7 @@ class ManifestResult {
   final int totalDirectories;
   final int totalFiles;
   final List<ManifestEntry> entries;
+  final List<List<String>> duplicateGroups;
 
   ManifestResult({
     required this.selectedFolder,
@@ -47,6 +51,7 @@ class ManifestResult {
     required this.totalDirectories,
     required this.totalFiles,
     required this.entries,
+    this.duplicateGroups = const [],
   });
 
   factory ManifestResult.fromJson(Map<String, dynamic> json) {
@@ -79,6 +84,15 @@ class ManifestResult {
       return a.entryType.compareTo(b.entryType);
     });
 
+    final List<dynamic> rawGroups =
+        json['duplicate_groups'] as List<dynamic>? ?? [];
+    final duplicateGroups = rawGroups
+        .map(
+          (dynamic group) =>
+              (group as List<dynamic>).map((e) => e as String).toList(),
+        )
+        .toList();
+
     return ManifestResult(
       selectedFolder: json['selected_folder'] as String? ?? '',
       exists: json['exists'] as bool? ?? false,
@@ -86,6 +100,7 @@ class ManifestResult {
       totalDirectories: json['total_directories'] as int? ?? 0,
       totalFiles: json['total_files'] as int? ?? 0,
       entries: entries,
+      duplicateGroups: duplicateGroups,
     );
   }
 }

--- a/rust_core/Cargo.lock
+++ b/rust_core/Cargo.lock
@@ -3,16 +3,208 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -33,12 +225,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rust_core"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
 ]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -84,6 +304,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,10 +326,196 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zmij"

--- a/rust_core/Cargo.toml
+++ b/rust_core/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2024"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
+hex = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -1,6 +1,10 @@
+use hex;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::env;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 #[derive(Serialize)]
@@ -8,6 +12,7 @@ struct ManifestEntry {
     relative_path: String,
     entry_type: String,
     size_bytes: Option<u64>,
+    sha256: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -18,6 +23,43 @@ struct ManifestResult {
     total_directories: usize,
     total_files: usize,
     entries: Vec<ManifestEntry>,
+    duplicate_groups: Vec<Vec<String>>,
+}
+
+fn hash_file(path: &Path) -> Option<String> {
+    let mut file = fs::File::open(path).ok()?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 65536];
+    loop {
+        let n = file.read(&mut buffer).ok()?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buffer[..n]);
+    }
+    Some(hex::encode(hasher.finalize()))
+}
+
+fn build_duplicate_groups(entries: &[ManifestEntry]) -> Vec<Vec<String>> {
+    let mut by_hash: HashMap<&str, Vec<&str>> = HashMap::new();
+    for entry in entries {
+        if entry.entry_type == "file" {
+            if let Some(hash) = &entry.sha256 {
+                by_hash.entry(hash).or_default().push(&entry.relative_path);
+            }
+        }
+    }
+    let mut groups: Vec<Vec<String>> = by_hash
+        .into_values()
+        .filter(|paths| paths.len() >= 2)
+        .map(|paths| {
+            let mut sorted: Vec<String> = paths.iter().map(|s| s.to_string()).collect();
+            sorted.sort();
+            sorted
+        })
+        .collect();
+    groups.sort_by(|a, b| a[0].cmp(&b[0]));
+    groups
 }
 
 fn main() {
@@ -57,12 +99,15 @@ fn main() {
             .cmp(&b.relative_path.to_lowercase())
     });
 
+    let duplicate_groups = build_duplicate_groups(&entries);
+
     let result = ManifestResult {
         selected_folder: folder_path.to_string(),
         exists,
         is_directory,
         total_directories,
         total_files,
+        duplicate_groups,
         entries,
     };
 
@@ -102,6 +147,7 @@ fn walk_directory(
                 relative_path,
                 entry_type: "directory".to_string(),
                 size_bytes: None,
+                sha256: None,
             });
 
             walk_directory(
@@ -113,20 +159,317 @@ fn walk_directory(
             )?;
         } else if metadata.is_file() {
             *total_files += 1;
+            let sha256 = hash_file(&entry_path);
 
             entries.push(ManifestEntry {
                 relative_path,
                 entry_type: "file".to_string(),
                 size_bytes: Some(metadata.len()),
+                sha256,
             });
         } else {
             entries.push(ManifestEntry {
                 relative_path,
                 entry_type: "other".to_string(),
                 size_bytes: None,
+                sha256: None,
             });
         }
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_file(dir: &Path, name: &str, content: &[u8]) -> PathBuf {
+        let path = dir.join(name);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(content).unwrap();
+        path
+    }
+
+    // --- hash_file ---
+
+    #[test]
+    fn test_hash_file_is_consistent() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "test.txt", b"hello world");
+        assert_eq!(hash_file(&path), hash_file(&path));
+    }
+
+    #[test]
+    fn test_hash_file_length_is_64_chars() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "test.txt", b"hello");
+        assert_eq!(hash_file(&path).unwrap().len(), 64);
+    }
+
+    #[test]
+    fn test_hash_file_differs_for_different_content() {
+        let dir = TempDir::new().unwrap();
+        let a = write_file(dir.path(), "a.txt", b"hello");
+        let b = write_file(dir.path(), "b.txt", b"world");
+        assert_ne!(hash_file(&a), hash_file(&b));
+    }
+
+    #[test]
+    fn test_hash_file_matches_for_same_content() {
+        let dir = TempDir::new().unwrap();
+        let a = write_file(dir.path(), "a.txt", b"duplicate");
+        let b = write_file(dir.path(), "b.txt", b"duplicate");
+        assert_eq!(hash_file(&a), hash_file(&b));
+    }
+
+    #[test]
+    fn test_hash_file_empty_file() {
+        // SHA-256 of zero bytes is a well-defined constant — verify we produce it.
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "empty.txt", b"");
+        let hash = hash_file(&path).unwrap();
+        assert_eq!(hash.len(), 64);
+        assert_eq!(
+            hash,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn test_hash_file_large_file_exercises_buffer_loop() {
+        // Write 200 KB — forces the 65536-byte read buffer to loop multiple times.
+        let dir = TempDir::new().unwrap();
+        let content = vec![0xABu8; 200 * 1024];
+        let a = write_file(dir.path(), "a.bin", &content);
+        let b = write_file(dir.path(), "b.bin", &content);
+        let hash_a = hash_file(&a).unwrap();
+        let hash_b = hash_file(&b).unwrap();
+        assert_eq!(hash_a.len(), 64);
+        assert_eq!(hash_a, hash_b);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_hash_file_returns_none_for_unreadable_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let path = write_file(dir.path(), "secret.txt", b"secret");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+        let result = hash_file(&path);
+        // Restore permissions so TempDir can clean up.
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(result.is_none(), "Expected None for unreadable file");
+    }
+
+    // --- build_duplicate_groups ---
+
+    #[test]
+    fn test_duplicate_groups_empty_input() {
+        assert!(build_duplicate_groups(&[]).is_empty());
+    }
+
+    #[test]
+    fn test_duplicate_groups_no_duplicates() {
+        let entries = vec![
+            ManifestEntry {
+                relative_path: "a.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("aaaa".into()),
+            },
+            ManifestEntry {
+                relative_path: "b.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("bbbb".into()),
+            },
+        ];
+        assert!(build_duplicate_groups(&entries).is_empty());
+    }
+
+    #[test]
+    fn test_duplicate_groups_detects_pair() {
+        let entries = vec![
+            ManifestEntry {
+                relative_path: "a.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("same".into()),
+            },
+            ManifestEntry {
+                relative_path: "b.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("same".into()),
+            },
+            ManifestEntry {
+                relative_path: "c.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("different".into()),
+            },
+        ];
+        let groups = build_duplicate_groups(&entries);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0], vec!["a.txt", "b.txt"]);
+    }
+
+    #[test]
+    fn test_duplicate_groups_detects_three_way_group() {
+        let entries = vec![
+            ManifestEntry {
+                relative_path: "a.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("same".into()),
+            },
+            ManifestEntry {
+                relative_path: "b.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("same".into()),
+            },
+            ManifestEntry {
+                relative_path: "c.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("same".into()),
+            },
+        ];
+        let groups = build_duplicate_groups(&entries);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0], vec!["a.txt", "b.txt", "c.txt"]);
+    }
+
+    #[test]
+    fn test_duplicate_groups_two_independent_groups() {
+        let entries = vec![
+            ManifestEntry {
+                relative_path: "a.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("hash_x".into()),
+            },
+            ManifestEntry {
+                relative_path: "b.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("hash_x".into()),
+            },
+            ManifestEntry {
+                relative_path: "c.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("hash_y".into()),
+            },
+            ManifestEntry {
+                relative_path: "d.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("hash_y".into()),
+            },
+        ];
+        let groups = build_duplicate_groups(&entries);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0], vec!["a.txt", "b.txt"]);
+        assert_eq!(groups[1], vec!["c.txt", "d.txt"]);
+    }
+
+    #[test]
+    fn test_duplicate_groups_ignores_directories() {
+        let entries = vec![
+            ManifestEntry {
+                relative_path: "dir_a".into(),
+                entry_type: "directory".into(),
+                size_bytes: None,
+                sha256: None,
+            },
+            ManifestEntry {
+                relative_path: "a.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("same".into()),
+            },
+            ManifestEntry {
+                relative_path: "b.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("same".into()),
+            },
+        ];
+        let groups = build_duplicate_groups(&entries);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0], vec!["a.txt", "b.txt"]);
+    }
+
+    #[test]
+    fn test_duplicate_groups_skips_file_with_no_hash() {
+        // A file whose hash is None (e.g. unreadable) must not crash or pollute groups.
+        let entries = vec![
+            ManifestEntry {
+                relative_path: "a.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: Some("same".into()),
+            },
+            ManifestEntry {
+                relative_path: "b.txt".into(),
+                entry_type: "file".into(),
+                size_bytes: Some(5),
+                sha256: None,
+            },
+        ];
+        assert!(build_duplicate_groups(&entries).is_empty());
+    }
+
+    // --- walker + corpus integration ---
+
+    #[test]
+    fn test_walker_detects_duplicates_in_corpus() {
+        // Fixture: alpha.txt, beta.txt, subdir/gamma.txt all contain
+        // "duplicate file content"; delta.txt is unique.
+        // Expect exactly one group containing those three paths.
+        let corpus_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("test_corpus/duplicates");
+
+        let mut entries = Vec::new();
+        let mut total_dirs = 0;
+        let mut total_files = 0;
+
+        walk_directory(
+            &corpus_path,
+            &corpus_path,
+            &mut entries,
+            &mut total_dirs,
+            &mut total_files,
+        )
+        .unwrap();
+
+        assert_eq!(total_files, 4, "Fixture should have exactly 4 files");
+        assert_eq!(total_dirs, 1, "Fixture should have exactly 1 subdirectory");
+
+        let groups = build_duplicate_groups(&entries);
+        assert_eq!(groups.len(), 1, "Expected exactly one duplicate group");
+
+        let mut group = groups[0].clone();
+        group.sort();
+        assert_eq!(
+            group,
+            vec!["alpha.txt", "beta.txt", "subdir/gamma.txt"],
+            "Group members don't match expected fixture paths"
+        );
+
+        // Verify the unique file is absent from all groups.
+        let grouped_paths: Vec<&str> = groups.iter().flatten().map(String::as_str).collect();
+        assert!(
+            !grouped_paths.contains(&"delta.txt"),
+            "delta.txt should not appear in any duplicate group"
+        );
+    }
 }

--- a/test/manifest_service_test.dart
+++ b/test/manifest_service_test.dart
@@ -22,6 +22,23 @@ void main() {
       'docs',
       'docs/readme.txt',
     ]);
+    expect(result.entries.last.sha256, 'abc123');
+    expect(result.duplicateGroups, isEmpty);
+  });
+
+  test('buildManifest parses duplicate_groups from Rust output', () async {
+    const service = ManifestService(
+      rustBinaryResolver: _fakeRustBinary,
+      processRunner: _duplicatesProcessRun,
+    );
+
+    final result = await service.buildManifest('/tmp/example');
+
+    expect(result.duplicateGroups, hasLength(1));
+    expect(
+      result.duplicateGroups.first,
+      containsAll(<String>['a.txt', 'b.txt']),
+    );
   });
 
   test('buildManifest surfaces Rust process failures', () async {
@@ -59,16 +76,49 @@ Future<ProcessResult> _successfulProcessRun(
   "is_directory": true,
   "total_directories": 1,
   "total_files": 1,
+  "duplicate_groups": [],
   "entries": [
     {
       "relative_path": "docs",
       "entry_type": "directory",
-      "size_bytes": null
+      "size_bytes": null,
+      "sha256": null
     },
     {
       "relative_path": "docs/readme.txt",
       "entry_type": "file",
-      "size_bytes": 512
+      "size_bytes": 512,
+      "sha256": "abc123"
+    }
+  ]
+}
+''', '');
+}
+
+Future<ProcessResult> _duplicatesProcessRun(
+  String executable,
+  List<String> arguments,
+) async {
+  return ProcessResult(1, 0, '''
+{
+  "selected_folder": "/tmp/example",
+  "exists": true,
+  "is_directory": true,
+  "total_directories": 0,
+  "total_files": 2,
+  "duplicate_groups": [["a.txt", "b.txt"]],
+  "entries": [
+    {
+      "relative_path": "a.txt",
+      "entry_type": "file",
+      "size_bytes": 10,
+      "sha256": "samehash"
+    },
+    {
+      "relative_path": "b.txt",
+      "entry_type": "file",
+      "size_bytes": 10,
+      "sha256": "samehash"
     }
   ]
 }

--- a/test_corpus/duplicates/alpha.txt
+++ b/test_corpus/duplicates/alpha.txt
@@ -1,0 +1,1 @@
+duplicate file content

--- a/test_corpus/duplicates/beta.txt
+++ b/test_corpus/duplicates/beta.txt
@@ -1,0 +1,1 @@
+duplicate file content

--- a/test_corpus/duplicates/delta.txt
+++ b/test_corpus/duplicates/delta.txt
@@ -1,0 +1,1 @@
+unique file content

--- a/test_corpus/duplicates/subdir/gamma.txt
+++ b/test_corpus/duplicates/subdir/gamma.txt
@@ -1,0 +1,1 @@
+duplicate file content


### PR DESCRIPTION
## Summary

- Rust engine now SHA-256 hashes every file during a scan (streaming 64KB buffer for large-file safety) and emits a `duplicate_groups` array in the JSON output
- Dart models updated to parse `sha256` per entry and `duplicate_groups` from the manifest result
- Flutter UI adds a **Duplicate Groups** section showing each group of identical files, plus a group count in the summary card

## Test coverage

- 15 Rust unit tests: hashing consistency, empty file, large file (>64KB buffer), unreadable file graceful handling, pair/three-way/multi-group detection, directory exclusion, missing-hash skipping, and a pinned corpus integration test with exact expected paths
- 3 Flutter tests: JSON parsing for sha256, duplicate_groups, and error handling
- New `test_corpus/duplicates/` fixture with 3 identical files across subdirectories + 1 unique file

## Notes

- Identified a real-world need for a progress indicator during scans — logged for top of Iteration 2 (streaming JSON protocol from Rust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)