### PR TITLE
Iter 3: before/after directory tree redesign for Rationalize screen

### DIFF
--- a/lib/rationalize_screen.dart
+++ b/lib/rationalize_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 
@@ -21,6 +19,13 @@ const _kIssueBadge = Color(0xFFCD3131);
 const _kWarningBadge = Color(0xFFCCA700);
 const _kSuccessBadge = Color(0xFF16825D);
 
+// Finding action colours — defined as named constants so the palette is a
+// one-line change once we validate legibility against real data.
+const _kRemoveColor = Color(0xFFCD3131); // red — proposed removal
+const _kRenameColor = Color(0xFFCCA700); // orange — proposed rename
+const _kMoveColor = Color(0xFF4FC1FF); // blue — proposed move
+const _kRenameTargetColor = Color(0xFF89D185); // green italic — in right panel
+
 // ---------------------------------------------------------------------------
 // Phase enum
 // ---------------------------------------------------------------------------
@@ -29,9 +34,36 @@ enum _Phase {
   folderPicker,
   scanning,
   findings,
-  previewing,
   executing,
   results,
+}
+
+// ---------------------------------------------------------------------------
+// _TreeNode — one row in either the original or target tree
+// ---------------------------------------------------------------------------
+
+class _TreeNode {
+  final String relativePath;
+  final String name;
+  final int depth;
+
+  /// The finding on this exact path, if any.
+  final RationalizeFinding? finding;
+
+  /// True when the node is showing an accepted rename's new name.
+  final bool isRenamedTarget;
+
+  /// True when the node is showing an accepted move's destination.
+  final bool isMovedTarget;
+
+  const _TreeNode({
+    required this.relativePath,
+    required this.name,
+    required this.depth,
+    this.finding,
+    this.isRenamedTarget = false,
+    this.isMovedTarget = false,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -58,15 +90,157 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
 
   // Findings state
   FindingsPayload? _payload;
-  final Set<String> _selectedIds = {};
-  final Set<String> _dismissedIds = {};
-  final Map<String, String> _destinationOverrides = {}; // id → abs path
 
-  // Bidirectional selection
-  String? _focusedFindingId;
+  // Accept/Reject decisions: finding id → true (accepted) / false (rejected).
+  // Absent key = unresolved. Unresolved = skipped at execution time.
+  final Map<String, bool> _decisions = {};
+
+  // User-overridden destination paths for rename/move: finding id → abs path.
+  final Map<String, String> _destinationOverrides = {};
+
+  // Currently open detail drawer.
+  String? _drawerFindingId;
 
   // Execution
   ExecutionResult? _executionResult;
+
+  // ---------------------------------------------------------------------------
+  // Computed properties
+  // ---------------------------------------------------------------------------
+
+  Set<String> get _acceptedIds =>
+      _decisions.entries.where((e) => e.value).map((e) => e.key).toSet();
+
+  int get _unresolvedCount {
+    final p = _payload;
+    if (p == null) return 0;
+    return p.findings.where((f) => !_decisions.containsKey(f.id)).length;
+  }
+
+  String _effectiveDestination(RationalizeFinding f) =>
+      _destinationOverrides[f.id] ?? f.absoluteDestination ?? '';
+
+  // ---------------------------------------------------------------------------
+  // Tree building
+  // ---------------------------------------------------------------------------
+
+  /// Sorted list of nodes derived from all finding paths + their ancestors.
+  List<_TreeNode> _buildOriginalTree(FindingsPayload payload) {
+    final pathToFinding = <String, RationalizeFinding>{};
+    for (final f in payload.findings) {
+      pathToFinding[f.path] = f;
+    }
+
+    final allPaths = <String>{};
+    for (final f in payload.findings) {
+      var path = f.path;
+      while (path.isNotEmpty) {
+        allPaths.add(path);
+        final slash = path.lastIndexOf('/');
+        if (slash < 0) break;
+        path = path.substring(0, slash);
+      }
+    }
+
+    final sorted = allPaths.toList()..sort();
+    return sorted.map((path) {
+      final depth = path.split('/').length - 1;
+      return _TreeNode(
+        relativePath: path,
+        name: path.split('/').last,
+        depth: depth,
+        finding: pathToFinding[path],
+      );
+    }).toList();
+  }
+
+  /// Compute the target tree by applying accepted actions to the original tree.
+  List<_TreeNode> _buildTargetTree(FindingsPayload payload) {
+    final accepted = _acceptedIds;
+    final original = _buildOriginalTree(payload);
+
+    // Paths that will be removed (accepted remove actions).
+    final removedPaths = <String>{};
+    for (final f in payload.findings) {
+      if (accepted.contains(f.id) && f.action == FindingAction.remove) {
+        removedPaths.add(f.path);
+      }
+    }
+
+    final result = <_TreeNode>[];
+
+    for (final node in original) {
+      // Omit nodes under accepted removals.
+      final isRemoved = removedPaths.any((rp) =>
+          node.relativePath == rp || node.relativePath.startsWith('$rp/'));
+      if (isRemoved) continue;
+
+      final f = node.finding;
+      if (f != null && accepted.contains(f.id)) {
+        if (f.action == FindingAction.rename) {
+          // Show with new name in green italic.
+          final dest = _effectiveDestination(f);
+          final newName =
+              dest.isNotEmpty ? dest.split('/').last : node.name;
+          result.add(_TreeNode(
+            relativePath: node.relativePath,
+            name: newName,
+            depth: node.depth,
+            finding: f,
+            isRenamedTarget: true,
+          ));
+          continue;
+        } else if (f.action == FindingAction.move) {
+          // Omit from original location; will appear at destination below.
+          continue;
+        }
+      }
+
+      result.add(node);
+    }
+
+    // Add accepted move destinations.
+    for (final f in payload.findings) {
+      if (!accepted.contains(f.id) || f.action != FindingAction.move) continue;
+      final dest = _effectiveDestination(f);
+      if (dest.isEmpty) continue;
+
+      final selectedFolder = payload.selectedFolder;
+      final rel = dest.startsWith(selectedFolder)
+          ? dest.substring(selectedFolder.length).replaceAll(RegExp(r'^/'), '')
+          : dest.split('/').last;
+      if (rel.isEmpty) continue;
+
+      result.add(_TreeNode(
+        relativePath: rel,
+        name: rel.split('/').last,
+        depth: rel.split('/').length - 1,
+        finding: f,
+        isMovedTarget: true,
+      ));
+    }
+
+    result.sort((a, b) => a.relativePath.compareTo(b.relativePath));
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Accept / Reject
+  // ---------------------------------------------------------------------------
+
+  void _accept(String id) => setState(() {
+        _decisions[id] = true;
+        if (_drawerFindingId == id) _drawerFindingId = null;
+      });
+
+  void _reject(String id) => setState(() {
+        _decisions[id] = false;
+        if (_drawerFindingId == id) _drawerFindingId = null;
+      });
+
+  void _openDrawer(String id) => setState(() => _drawerFindingId = id);
+
+  void _closeDrawer() => setState(() => _drawerFindingId = null);
 
   // ---------------------------------------------------------------------------
   // Scan
@@ -82,10 +256,9 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
       _foldersScanned = 0;
       _currentPath = '';
       _payload = null;
-      _selectedIds.clear();
-      _dismissedIds.clear();
+      _decisions.clear();
       _destinationOverrides.clear();
-      _focusedFindingId = null;
+      _drawerFindingId = null;
       _executionResult = null;
     });
 
@@ -119,106 +292,24 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
   }
 
   // ---------------------------------------------------------------------------
-  // Selection helpers
+  // Execute
   // ---------------------------------------------------------------------------
 
-  List<RationalizeFinding> get _visibleFindings {
-    final p = _payload;
-    if (p == null) return [];
-    return p.findings.where((f) => !_dismissedIds.contains(f.id)).toList();
-  }
-
-  List<RationalizeFinding> _visibleFindingsOfType(FindingType type) =>
-      _visibleFindings.where((f) => f.findingType == type).toList();
-
-  bool _allCheckedForType(FindingType type) {
-    final visible = _visibleFindingsOfType(type);
-    if (visible.isEmpty) return false;
-    return visible.every((f) => _selectedIds.contains(f.id));
-  }
-
-  bool _someCheckedForType(FindingType type) {
-    final visible = _visibleFindingsOfType(type);
-    return visible.any((f) => _selectedIds.contains(f.id)) &&
-        !_allCheckedForType(type);
-  }
-
-  void _toggleGroupAll(FindingType type) {
-    final visible = _visibleFindingsOfType(type);
-    setState(() {
-      if (_allCheckedForType(type)) {
-        for (final f in visible) {
-          _selectedIds.remove(f.id);
-        }
-      } else {
-        for (final f in visible) {
-          _selectedIds.add(f.id);
-        }
-      }
-    });
-  }
-
-  void _toggleFinding(String id) {
-    setState(() {
-      if (_selectedIds.contains(id)) {
-        _selectedIds.remove(id);
-      } else {
-        _selectedIds.add(id);
-      }
-    });
-  }
-
-  void _dismissFinding(String id) {
-    setState(() {
-      _dismissedIds.add(id);
-      _selectedIds.remove(id);
-      if (_focusedFindingId == id) _focusedFindingId = null;
-    });
-  }
-
-  void _focusFinding(String id) {
-    setState(() => _focusedFindingId = id);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Destination override
-  // ---------------------------------------------------------------------------
-
-  String _effectiveDestination(RationalizeFinding finding) {
-    return _destinationOverrides[finding.id] ??
-        finding.absoluteDestination ??
-        '';
-  }
-
-  // ---------------------------------------------------------------------------
-  // Preview & Execute
-  // ---------------------------------------------------------------------------
-
-  void _openPreview() {
-    setState(() => _phase = _Phase.previewing);
-  }
-
-  void _closePreview() {
-    setState(() => _phase = _Phase.findings);
-  }
-
-  Future<void> _applySelected() async {
+  Future<void> _applyAccepted() async {
     final session = _session;
     final payload = _payload;
     final folder = _selectedFolder;
     if (session == null || payload == null || folder == null) return;
 
-    // Build session ID from current time (matches Rust format YYYY-MM-DDTHH-MM-SS)
     final now = DateTime.now().toUtc();
-    final sessionId =
-        '${now.year.toString().padLeft(4, '0')}-'
+    final sessionId = '${now.year.toString().padLeft(4, '0')}-'
         '${now.month.toString().padLeft(2, '0')}-'
         '${now.day.toString().padLeft(2, '0')}T'
         '${now.hour.toString().padLeft(2, '0')}-'
         '${now.minute.toString().padLeft(2, '0')}-'
         '${now.second.toString().padLeft(2, '0')}';
 
-    final actions = _selectedIds
+    final actions = _acceptedIds
         .map((id) => payload.findById(id))
         .whereType<RationalizeFinding>()
         .map((f) => ExecutionActionItem(
@@ -259,22 +350,72 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
   }
 
   // ---------------------------------------------------------------------------
+  // Context menu
+  // ---------------------------------------------------------------------------
+
+  void _showContextMenu(
+      BuildContext ctx, Offset globalPos, RationalizeFinding? finding) {
+    final items = <PopupMenuEntry<String>>[
+      if (finding != null) ...[
+        PopupMenuItem(
+          value: 'accept',
+          child: Text(
+            'Accept — ${_actionLabel(finding)}',
+            style: const TextStyle(fontSize: 13),
+          ),
+        ),
+        const PopupMenuItem(
+          value: 'reject',
+          child: Text('Reject this finding', style: TextStyle(fontSize: 13)),
+        ),
+        const PopupMenuDivider(),
+      ],
+      const PopupMenuItem(
+        value: 'remove',
+        enabled: false, // user-initiated removal: Iteration 4 (#46)
+        child: Text('Mark for removal (coming soon)',
+            style: TextStyle(fontSize: 13)),
+      ),
+    ];
+
+    showMenu<String>(
+      context: ctx,
+      position: RelativeRect.fromLTRB(
+          globalPos.dx, globalPos.dy, globalPos.dx + 1, globalPos.dy + 1),
+      color: const Color(0xFF2D2D30),
+      items: items,
+    ).then((value) {
+      if (value == null || finding == null) return;
+      if (value == 'accept') _accept(finding.id);
+      if (value == 'reject') _reject(finding.id);
+    });
+  }
+
+  String _actionLabel(RationalizeFinding f) => switch (f.action) {
+        FindingAction.remove => 'Remove',
+        FindingAction.rename => () {
+            final dest = _effectiveDestination(f);
+            final name = dest.isNotEmpty ? dest.split('/').last : '';
+            return 'Rename to "$name"';
+          }(),
+        FindingAction.move => 'Move to ${f.destination ?? ''}',
+      };
+
+  // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
 
   void _showError(String message) {
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(message, style: const TextStyle(color: Colors.white)),
-        backgroundColor: _kIssueBadge,
-        duration: const Duration(seconds: 6),
-      ),
-    );
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(message, style: const TextStyle(color: Colors.white)),
+      backgroundColor: _kIssueBadge,
+      duration: const Duration(seconds: 6),
+    ));
   }
 
   // ---------------------------------------------------------------------------
-  // Build
+  // Lifecycle
   // ---------------------------------------------------------------------------
 
   @override
@@ -282,6 +423,10 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
     _session?.dispose();
     super.dispose();
   }
+
+  // ---------------------------------------------------------------------------
+  // Build
+  // ---------------------------------------------------------------------------
 
   @override
   Widget build(BuildContext context) {
@@ -319,16 +464,13 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
     );
   }
 
-  Widget _buildBody() {
-    return switch (_phase) {
-      _Phase.folderPicker => _buildFolderPicker(),
-      _Phase.scanning => _buildScanning(),
-      _Phase.findings => _buildFindingsView(),
-      _Phase.previewing => _buildPreviewView(),
-      _Phase.executing => _buildExecuting(),
-      _Phase.results => _buildResults(),
-    };
-  }
+  Widget _buildBody() => switch (_phase) {
+        _Phase.folderPicker => _buildFolderPicker(),
+        _Phase.scanning => _buildScanning(),
+        _Phase.findings => _buildFindingsView(),
+        _Phase.executing => _buildExecuting(),
+        _Phase.results => _buildResults(),
+      };
 
   // ---------------------------------------------------------------------------
   // Phase: Folder picker
@@ -341,10 +483,8 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
         children: [
           const Icon(Icons.folder_open, size: 64, color: _kSubtext),
           const SizedBox(height: 16),
-          const Text(
-            'Choose a folder to rationalize',
-            style: TextStyle(color: _kText, fontSize: 16),
-          ),
+          const Text('Choose a folder to rationalize',
+              style: TextStyle(color: _kText, fontSize: 16)),
           const SizedBox(height: 8),
           const Text(
             'FileSteward will analyze the folder structure and\n'
@@ -382,23 +522,16 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
           children: [
             const CircularProgressIndicator(color: _kBlue),
             const SizedBox(height: 24),
-            Text(
-              'Scanning folder structure…',
-              style: const TextStyle(color: _kText, fontSize: 14),
-            ),
+            const Text('Scanning folder structure…',
+                style: TextStyle(color: _kText, fontSize: 14)),
             const SizedBox(height: 8),
-            Text(
-              '$_foldersScanned folders scanned',
-              style: const TextStyle(color: _kSubtext, fontSize: 12),
-            ),
+            Text('$_foldersScanned folders scanned',
+                style: const TextStyle(color: _kSubtext, fontSize: 12)),
             if (_currentPath.isNotEmpty) ...[
               const SizedBox(height: 4),
-              Text(
-                _currentPath,
-                style:
-                    const TextStyle(color: _kSubtext, fontSize: 11),
-                overflow: TextOverflow.ellipsis,
-              ),
+              Text(_currentPath,
+                  style: const TextStyle(color: _kSubtext, fontSize: 11),
+                  overflow: TextOverflow.ellipsis),
             ],
           ],
         ),
@@ -407,152 +540,73 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
   }
 
   // ---------------------------------------------------------------------------
-  // Phase: Findings two-panel view
+  // Phase: Findings — before/after tree panels
   // ---------------------------------------------------------------------------
 
   Widget _buildFindingsView() {
     final payload = _payload!;
-    final selectedCount = _selectedIds.length;
+    final originalNodes = _buildOriginalTree(payload);
+    final targetNodes = _buildTargetTree(payload);
+    final accepted = _acceptedIds;
+    final drawerFinding = _drawerFindingId != null
+        ? payload.findById(_drawerFindingId!)
+        : null;
 
     return Column(
       children: [
         Expanded(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
+          child: Stack(
             children: [
-              // Left: findings panel
-              SizedBox(
-                width: 420,
-                child: _FindingsPanel(
-                  payload: payload,
-                  visibleFindings: _visibleFindings,
-                  selectedIds: _selectedIds,
-                  focusedId: _focusedFindingId,
-                  destinationOverrides: _destinationOverrides,
-                  onToggle: _toggleFinding,
-                  onDismiss: _dismissFinding,
-                  onFocus: _focusFinding,
-                  onGroupAllToggle: _toggleGroupAll,
-                  isAllChecked: _allCheckedForType,
-                  isSomeChecked: _someCheckedForType,
-                  onDestinationChanged: (id, path) => setState(
-                    () => _destinationOverrides[id] = path,
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // Left panel — original state
+                  Expanded(
+                    child: _OriginalTreePanel(
+                      nodes: originalNodes,
+                      decisions: _decisions,
+                      drawerFindingId: _drawerFindingId,
+                      onNodeTap: (f) {
+                        if (f != null) _openDrawer(f.id);
+                      },
+                      onNodeRightClick: _showContextMenu,
+                    ),
+                  ),
+                  Container(width: 1, color: _kDivider),
+                  // Right panel — target state
+                  Expanded(
+                    child: _TargetTreePanel(
+                      nodes: targetNodes,
+                      drawerFindingId: _drawerFindingId,
+                      onNodeTap: (f) {
+                        if (f != null) _openDrawer(f.id);
+                      },
+                    ),
+                  ),
+                ],
+              ),
+              // Detail drawer slides in over the right panel
+              if (drawerFinding != null)
+                _DetailDrawerOverlay(
+                  finding: drawerFinding,
+                  decision: _decisions[drawerFinding.id],
+                  destinationOverride:
+                      _destinationOverrides[drawerFinding.id],
+                  onAccept: () => _accept(drawerFinding.id),
+                  onReject: () => _reject(drawerFinding.id),
+                  onClose: _closeDrawer,
+                  onDestinationChanged: (path) => setState(
+                    () => _destinationOverrides[drawerFinding.id] = path,
                   ),
                 ),
-              ),
-              Container(width: 1, color: _kDivider),
-              // Right: folder tree
-              Expanded(
-                child: _TreePanel(
-                  payload: payload,
-                  selectedIds: _selectedIds,
-                  dismissedIds: _dismissedIds,
-                  focusedId: _focusedFindingId,
-                  onFocus: _focusFinding,
-                ),
-              ),
             ],
           ),
         ),
         Container(height: 1, color: _kDivider),
         _BottomBar(
-          selectedCount: selectedCount,
-          totalVisible: _visibleFindings.length,
-          onPreview: selectedCount > 0 ? _openPreview : null,
-          onApply: selectedCount > 0 ? _applySelected : null,
-        ),
-      ],
-    );
-  }
-
-  // ---------------------------------------------------------------------------
-  // Phase: Preview
-  // ---------------------------------------------------------------------------
-
-  Widget _buildPreviewView() {
-    final payload = _payload!;
-    final selected = _selectedIds
-        .map((id) => payload.findById(id))
-        .whereType<RationalizeFinding>()
-        .toList();
-
-    return Column(
-      children: [
-        Expanded(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  'Preview Changes',
-                  style: TextStyle(
-                      color: _kText,
-                      fontSize: 18,
-                      fontWeight: FontWeight.w600),
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  '${selected.length} action${selected.length != 1 ? 's' : ''} will be applied. '
-                  'Removed items are moved to quarantine — nothing is permanently deleted.',
-                  style:
-                      const TextStyle(color: _kSubtext, fontSize: 13),
-                ),
-                const SizedBox(height: 24),
-                ...selected.map((f) => _PreviewRow(
-                      finding: f,
-                      effectiveDestination: _effectiveDestination(f),
-                    )),
-                const SizedBox(height: 16),
-                Container(
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: _kPanelBg,
-                    borderRadius: BorderRadius.circular(6),
-                    border: Border.all(color: _kDivider),
-                  ),
-                  child: Row(
-                    children: [
-                      const Icon(Icons.archive_outlined,
-                          color: _kSubtext, size: 16),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          'Quarantine: ~/.filesteward/quarantine/',
-                          style: const TextStyle(
-                              color: _kSubtext, fontSize: 12),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-        Container(height: 1, color: _kDivider),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: _closePreview,
-                child: const Text('Cancel',
-                    style: TextStyle(color: _kSubtext)),
-              ),
-              const SizedBox(width: 8),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: _kBlue,
-                  foregroundColor: Colors.white,
-                ),
-                onPressed: _applySelected,
-                child: Text(
-                    'Apply ${_selectedIds.length} Change${_selectedIds.length != 1 ? 's' : ''}'),
-              ),
-            ],
-          ),
+          accepted: accepted.length,
+          unresolved: _unresolvedCount,
+          onApply: accepted.isNotEmpty ? _applyAccepted : null,
         ),
       ],
     );
@@ -569,15 +623,11 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
         children: [
           CircularProgressIndicator(color: _kBlue),
           SizedBox(height: 24),
-          Text(
-            'Applying changes…',
-            style: TextStyle(color: _kText, fontSize: 14),
-          ),
+          Text('Applying changes…',
+              style: TextStyle(color: _kText, fontSize: 14)),
           SizedBox(height: 8),
-          Text(
-            'Moving items to quarantine if needed.',
-            style: TextStyle(color: _kSubtext, fontSize: 12),
-          ),
+          Text('Moving items to quarantine if needed.',
+              style: TextStyle(color: _kSubtext, fontSize: 12)),
         ],
       ),
     );
@@ -595,7 +645,6 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
     }
 
     final allOk = result.failed == 0;
-
     return Center(
       child: SizedBox(
         width: 420,
@@ -603,7 +652,9 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
           mainAxisSize: MainAxisSize.min,
           children: [
             Icon(
-              allOk ? Icons.check_circle_outline : Icons.warning_amber_outlined,
+              allOk
+                  ? Icons.check_circle_outline
+                  : Icons.warning_amber_outlined,
               size: 48,
               color: allOk ? _kSuccessBadge : _kWarningBadge,
             ),
@@ -626,10 +677,10 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
             ),
             if (result.succeeded > 0) ...[
               const SizedBox(height: 8),
-              Text(
+              const Text(
                 'Removed items quarantined at:\n~/.filesteward/quarantine/',
                 textAlign: TextAlign.center,
-                style: const TextStyle(color: _kSubtext, fontSize: 12),
+                style: TextStyle(color: _kSubtext, fontSize: 12),
               ),
             ],
             const SizedBox(height: 24),
@@ -664,574 +715,58 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
 }
 
 // ---------------------------------------------------------------------------
-// _FindingsPanel — left panel
+// _OriginalTreePanel — left panel, colour-coded by action
 // ---------------------------------------------------------------------------
 
-class _FindingsPanel extends StatelessWidget {
-  const _FindingsPanel({
-    required this.payload,
-    required this.visibleFindings,
-    required this.selectedIds,
-    required this.focusedId,
-    required this.destinationOverrides,
-    required this.onToggle,
-    required this.onDismiss,
-    required this.onFocus,
-    required this.onGroupAllToggle,
-    required this.isAllChecked,
-    required this.isSomeChecked,
-    required this.onDestinationChanged,
+class _OriginalTreePanel extends StatelessWidget {
+  const _OriginalTreePanel({
+    required this.nodes,
+    required this.decisions,
+    required this.drawerFindingId,
+    required this.onNodeTap,
+    required this.onNodeRightClick,
   });
 
-  final FindingsPayload payload;
-  final List<RationalizeFinding> visibleFindings;
-  final Set<String> selectedIds;
-  final String? focusedId;
-  final Map<String, String> destinationOverrides;
-  final void Function(String id) onToggle;
-  final void Function(String id) onDismiss;
-  final void Function(String id) onFocus;
-  final void Function(FindingType type) onGroupAllToggle;
-  final bool Function(FindingType type) isAllChecked;
-  final bool Function(FindingType type) isSomeChecked;
-  final void Function(String id, String path) onDestinationChanged;
-
-  static const _groupOrder = [
-    FindingType.emptyFolder,
-    FindingType.namingInconsistency,
-    FindingType.misplacedFile,
-    FindingType.excessiveNesting,
-  ];
+  final List<_TreeNode> nodes;
+  final Map<String, bool> decisions;
+  final String? drawerFindingId;
+  final void Function(RationalizeFinding?) onNodeTap;
+  final void Function(BuildContext, Offset, RationalizeFinding?)
+      onNodeRightClick;
 
   @override
   Widget build(BuildContext context) {
-    if (visibleFindings.isEmpty) {
-      return const Center(
-        child: Padding(
-          padding: EdgeInsets.all(24),
-          child: Text(
-            'No findings. Your folder structure looks good!',
-            textAlign: TextAlign.center,
-            style: TextStyle(color: _kSubtext, fontSize: 13),
-          ),
-        ),
-      );
-    }
-
-    final groups = <FindingType, List<RationalizeFinding>>{};
-    for (final type in _groupOrder) {
-      final items =
-          visibleFindings.where((f) => f.findingType == type).toList();
-      if (items.isNotEmpty) groups[type] = items;
-    }
-
     return Column(
       children: [
-        // Header
-        Container(
-          height: 32,
-          padding: const EdgeInsets.symmetric(horizontal: 12),
-          color: _kPanelBg,
-          alignment: Alignment.centerLeft,
-          child: Text(
-            '${visibleFindings.length} finding${visibleFindings.length != 1 ? 's' : ''}',
-            style:
-                const TextStyle(color: _kSubtext, fontSize: 11),
-          ),
+        _PanelHeader(
+          title: 'Original',
+          subtitle: '${nodes.length} folders',
         ),
-        Container(height: 1, color: _kDivider),
-        // Groups
-        Expanded(
-          child: ListView(
-            children: [
-              for (final type in _groupOrder)
-                if (groups.containsKey(type)) ...[
-                  _FindingGroupHeader(
-                    type: type,
-                    count: groups[type]!.length,
-                    allChecked: isAllChecked(type),
-                    someChecked: isSomeChecked(type),
-                    onToggleAll: () => onGroupAllToggle(type),
-                  ),
-                  for (final finding in groups[type]!)
-                    _FindingRow(
-                      finding: finding,
-                      isSelected: selectedIds.contains(finding.id),
-                      isFocused: focusedId == finding.id,
-                      overridePath: destinationOverrides[finding.id],
-                      onToggle: () => onToggle(finding.id),
-                      onDismiss: () => onDismiss(finding.id),
-                      onTap: () => onFocus(finding.id),
-                      onDestinationChanged: (path) =>
-                          onDestinationChanged(finding.id, path),
-                    ),
-                ],
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// _FindingGroupHeader
-// ---------------------------------------------------------------------------
-
-class _FindingGroupHeader extends StatelessWidget {
-  const _FindingGroupHeader({
-    required this.type,
-    required this.count,
-    required this.allChecked,
-    required this.someChecked,
-    required this.onToggleAll,
-  });
-
-  final FindingType type;
-  final int count;
-  final bool allChecked;
-  final bool someChecked;
-  final VoidCallback onToggleAll;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onToggleAll,
-      child: Container(
-        height: 30,
-        color: const Color(0xFF2D2D30),
-        padding: const EdgeInsets.symmetric(horizontal: 12),
-        child: Row(
-          children: [
-            _TriStateCheckbox(
-              checked: allChecked,
-              indeterminate: someChecked,
-              onTap: onToggleAll,
-            ),
-            const SizedBox(width: 8),
-            _FindingTypeBadge(type: type),
-            const SizedBox(width: 8),
-            Text(
-              type.label,
-              style: const TextStyle(
-                  color: _kText,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600),
-            ),
-            const Spacer(),
-            Text(
-              '$count',
-              style: const TextStyle(color: _kSubtext, fontSize: 11),
-            ),
-            const SizedBox(width: 4),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// _FindingRow
-// ---------------------------------------------------------------------------
-
-class _FindingRow extends StatefulWidget {
-  const _FindingRow({
-    required this.finding,
-    required this.isSelected,
-    required this.isFocused,
-    required this.overridePath,
-    required this.onToggle,
-    required this.onDismiss,
-    required this.onTap,
-    required this.onDestinationChanged,
-  });
-
-  final RationalizeFinding finding;
-  final bool isSelected;
-  final bool isFocused;
-  final String? overridePath;
-  final VoidCallback onToggle;
-  final VoidCallback onDismiss;
-  final VoidCallback onTap;
-  final void Function(String path) onDestinationChanged;
-
-  @override
-  State<_FindingRow> createState() => _FindingRowState();
-}
-
-class _FindingRowState extends State<_FindingRow> {
-  bool _showOverrideInput = false;
-  final _overrideController = TextEditingController();
-
-  @override
-  void initState() {
-    super.initState();
-    _overrideController.text =
-        widget.overridePath ?? widget.finding.absoluteDestination ?? '';
-  }
-
-  @override
-  void dispose() {
-    _overrideController.dispose();
-    super.dispose();
-  }
-
-  String get _proposedAction {
-    switch (widget.finding.action) {
-      case FindingAction.remove:
-        return 'Remove → Quarantine';
-      case FindingAction.rename:
-        final dest = widget.overridePath ??
-            widget.finding.destination ??
-            '';
-        final name = dest.split('/').last;
-        return 'Rename to "$name"';
-      case FindingAction.move:
-        final dest = widget.overridePath ??
-            widget.finding.destination ??
-            '';
-        return 'Move to $dest';
-    }
-  }
-
-  bool get _canOverrideDestination =>
-      widget.finding.action != FindingAction.remove;
-
-  @override
-  Widget build(BuildContext context) {
-    final isFocused = widget.isFocused;
-    return GestureDetector(
-      onTap: widget.onTap,
-      child: Container(
-        color: isFocused
-            ? _kBlue.withValues(alpha: 0.15)
-            : Colors.transparent,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _TriStateCheckbox(
-                    checked: widget.isSelected,
-                    indeterminate: false,
-                    onTap: widget.onToggle,
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        // Name + dependency indicator
-                        Row(
-                          children: [
-                            Expanded(
-                              child: Text(
-                                widget.finding.displayName,
-                                style: const TextStyle(
-                                    color: _kText, fontSize: 13),
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                            if (widget.finding.isDependent)
-                              Padding(
-                                padding:
-                                    const EdgeInsets.only(left: 4),
-                                child: Text(
-                                  '↳ cascade',
-                                  style: const TextStyle(
-                                      color: _kSubtext, fontSize: 10),
-                                ),
-                              ),
-                          ],
-                        ),
-                        const SizedBox(height: 2),
-                        // Relative path
-                        Text(
-                          widget.finding.path,
-                          style: const TextStyle(
-                              color: _kSubtext, fontSize: 11),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        const SizedBox(height: 4),
-                        // Proposed action
-                        Text(
-                          _proposedAction,
-                          style: const TextStyle(
-                              color: _kSubtext, fontSize: 11),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        // Destination override link
-                        if (_canOverrideDestination) ...[
-                          const SizedBox(height: 4),
-                          GestureDetector(
-                            onTap: () => setState(
-                                () => _showOverrideInput = !_showOverrideInput),
-                            child: Text(
-                              _showOverrideInput
-                                  ? 'Cancel override'
-                                  : 'Choose location…',
-                              style: const TextStyle(
-                                  color: _kBlue,
-                                  fontSize: 11,
-                                  decoration: TextDecoration.underline),
-                            ),
-                          ),
-                        ],
-                        // Inline override input
-                        if (_showOverrideInput)
-                          _DestinationOverrideInput(
-                            controller: _overrideController,
-                            onChanged: widget.onDestinationChanged,
-                          ),
-                      ],
-                    ),
-                  ),
-                  // Dismiss button
-                  GestureDetector(
-                    onTap: widget.onDismiss,
-                    child: const Padding(
-                      padding: EdgeInsets.only(left: 8, top: 2),
-                      child: Icon(Icons.close,
-                          size: 14, color: _kSubtext),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Container(height: 1, color: _kDivider.withValues(alpha: 0.5)),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// _DestinationOverrideInput
-// ---------------------------------------------------------------------------
-
-class _DestinationOverrideInput extends StatefulWidget {
-  const _DestinationOverrideInput({
-    required this.controller,
-    required this.onChanged,
-  });
-
-  final TextEditingController controller;
-  final void Function(String path) onChanged;
-
-  @override
-  State<_DestinationOverrideInput> createState() =>
-      _DestinationOverrideInputState();
-}
-
-class _DestinationOverrideInputState
-    extends State<_DestinationOverrideInput> {
-  bool? _exists; // null = unchecked, true = exists, false = will be created
-
-  @override
-  void initState() {
-    super.initState();
-    _checkPath(widget.controller.text);
-    widget.controller.addListener(_handleChange);
-  }
-
-  @override
-  void dispose() {
-    widget.controller.removeListener(_handleChange);
-    super.dispose();
-  }
-
-  void _handleChange() {
-    _checkPath(widget.controller.text);
-    widget.onChanged(widget.controller.text.trim());
-  }
-
-  void _checkPath(String path) {
-    final trimmed = path.trim();
-    if (trimmed.isEmpty) {
-      if (mounted) setState(() => _exists = null);
-      return;
-    }
-    final exists = Directory(trimmed).existsSync();
-    if (mounted) setState(() => _exists = exists);
-  }
-
-  Future<void> _browse() async {
-    final path = await getDirectoryPath();
-    if (path != null && path.isNotEmpty) {
-      widget.controller.text = path;
-      widget.onChanged(path);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 6),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: TextField(
-                  controller: widget.controller,
-                  style: const TextStyle(
-                      color: _kText, fontSize: 11),
-                  decoration: InputDecoration(
-                    isDense: true,
-                    contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 8, vertical: 6),
-                    filled: true,
-                    fillColor: const Color(0xFF3C3C3C),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(4),
-                      borderSide: const BorderSide(
-                          color: _kDivider),
-                    ),
-                    enabledBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(4),
-                      borderSide:
-                          const BorderSide(color: _kDivider),
-                    ),
-                  ),
-                ),
-              ),
-              const SizedBox(width: 6),
-              TextButton(
-                style: TextButton.styleFrom(
-                  foregroundColor: _kText,
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 8, vertical: 6),
-                  minimumSize: Size.zero,
-                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                ),
-                onPressed: _browse,
-                child: const Text('Browse',
-                    style: TextStyle(fontSize: 11)),
-              ),
-            ],
-          ),
-          if (_exists != null) ...[
-            const SizedBox(height: 4),
-            Row(
-              children: [
-                Icon(
-                  Icons.circle,
-                  size: 8,
-                  color: _exists! ? _kSuccessBadge : _kWarningBadge,
-                ),
-                const SizedBox(width: 4),
-                Text(
-                  _exists! ? 'Folder exists' : 'Will be created',
-                  style: TextStyle(
-                    fontSize: 10,
-                    color: _exists! ? _kSuccessBadge : _kWarningBadge,
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// _TreePanel — right panel (Finder-style folder tree)
-// ---------------------------------------------------------------------------
-
-class _TreePanel extends StatelessWidget {
-  const _TreePanel({
-    required this.payload,
-    required this.selectedIds,
-    required this.dismissedIds,
-    required this.focusedId,
-    required this.onFocus,
-  });
-
-  final FindingsPayload payload;
-  final Set<String> selectedIds;
-  final Set<String> dismissedIds;
-  final String? focusedId;
-  final void Function(String id) onFocus;
-
-  @override
-  Widget build(BuildContext context) {
-    // Build a map: relative_path → list of (non-dismissed) finding IDs
-    final pathFindings = <String, List<RationalizeFinding>>{};
-    for (final f in payload.findings) {
-      if (!dismissedIds.contains(f.id)) {
-        pathFindings.putIfAbsent(f.path, () => []).add(f);
-      }
-    }
-
-    // Collect all unique folder paths from findings
-    final allPaths = <String>{};
-    for (final f in payload.findings) {
-      final parts = f.path.split('/');
-      for (int i = 1; i <= parts.length; i++) {
-        allPaths.add(parts.sublist(0, i).join('/'));
-      }
-    }
-    final sortedPaths = allPaths.toList()..sort();
-
-    return Column(
-      children: [
-        // Column headers
-        Container(
-          height: 32,
-          color: _kPanelBg,
-          padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: Row(
-            children: [
-              const Expanded(
-                flex: 5,
-                child: Text('Name',
-                    style:
-                        TextStyle(color: _kSubtext, fontSize: 11)),
-              ),
-              const SizedBox(
-                width: 120,
-                child: Text('Findings',
-                    style: TextStyle(
-                        color: _kSubtext, fontSize: 11)),
-              ),
-            ],
-          ),
-        ),
-        Container(height: 1, color: _kDivider),
-        // Tree rows
         Expanded(
           child: ListView.builder(
-            itemCount: sortedPaths.length,
-            itemBuilder: (context, index) {
-              final path = sortedPaths[index];
-              final depth =
-                  path.split('/').length - 1;
-              final name = path.split('/').last;
-              final findings = pathFindings[path] ?? [];
-              final focusedHere = findings.any(
-                  (f) => f.id == focusedId);
+            itemCount: nodes.length,
+            itemBuilder: (ctx, i) {
+              final node = nodes[i];
+              final f = node.finding;
 
-              return _TreeRow(
-                name: name,
-                depth: depth,
-                findings: findings,
-                isFocused: focusedHere,
-                hasDescendantFindings:
-                    pathFindings.keys.any((k) =>
-                        k.startsWith('$path/') &&
-                        pathFindings[k]!.isNotEmpty),
-                onTap: findings.isNotEmpty
-                    ? () => onFocus(findings.first.id)
-                    : null,
+              Color? nameColor;
+              if (f != null) {
+                nameColor = switch (f.action) {
+                  FindingAction.remove => _kRemoveColor,
+                  FindingAction.rename => _kRenameColor,
+                  FindingAction.move => _kMoveColor,
+                };
+              }
+
+              return _TreeNodeRow(
+                name: node.name,
+                depth: node.depth,
+                nameColor: nameColor,
+                isItalic: false,
+                decision: f != null ? decisions[f.id] : null,
+                isFocused: f != null && f.id == drawerFindingId,
+                onTap: f != null ? () => onNodeTap(f) : null,
+                onSecondaryTap: (pos) => onNodeRightClick(ctx, pos, f),
               );
             },
           ),
@@ -1242,63 +777,519 @@ class _TreePanel extends StatelessWidget {
 }
 
 // ---------------------------------------------------------------------------
-// _TreeRow
+// _TargetTreePanel — right panel, clean target state
 // ---------------------------------------------------------------------------
 
-class _TreeRow extends StatelessWidget {
-  const _TreeRow({
+class _TargetTreePanel extends StatelessWidget {
+  const _TargetTreePanel({
+    required this.nodes,
+    required this.drawerFindingId,
+    required this.onNodeTap,
+  });
+
+  final List<_TreeNode> nodes;
+  final String? drawerFindingId;
+  final void Function(RationalizeFinding?) onNodeTap;
+
+  @override
+  Widget build(BuildContext context) {
+    if (nodes.isEmpty) {
+      return Column(
+        children: [
+          _PanelHeader(title: 'Target', subtitle: '0 folders'),
+          const Expanded(
+            child: Center(
+              child: Text(
+                'Accept actions to see the target state.',
+                style: TextStyle(color: _kSubtext, fontSize: 13),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Column(
+      children: [
+        _PanelHeader(
+          title: 'Target',
+          subtitle: '${nodes.length} folders',
+        ),
+        Expanded(
+          child: ListView.builder(
+            itemCount: nodes.length,
+            itemBuilder: (_, i) {
+              final node = nodes[i];
+              final f = node.finding;
+
+              Color? nameColor;
+              bool isItalic = false;
+              if (node.isRenamedTarget || node.isMovedTarget) {
+                nameColor = _kRenameTargetColor;
+                isItalic = true;
+              }
+
+              return _TreeNodeRow(
+                name: node.name,
+                depth: node.depth,
+                nameColor: nameColor,
+                isItalic: isItalic,
+                decision: null,
+                isFocused: f != null && f.id == drawerFindingId,
+                onTap: f != null ? () => onNodeTap(f) : null,
+                onSecondaryTap: null,
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// _PanelHeader
+// ---------------------------------------------------------------------------
+
+class _PanelHeader extends StatelessWidget {
+  const _PanelHeader({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          height: 36,
+          color: _kPanelBg,
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Row(
+            children: [
+              Text(title,
+                  style: const TextStyle(
+                      color: _kText,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600)),
+              const SizedBox(width: 8),
+              Text(subtitle,
+                  style:
+                      const TextStyle(color: _kSubtext, fontSize: 11)),
+            ],
+          ),
+        ),
+        Container(height: 1, color: _kDivider),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// _TreeNodeRow — one row in either panel
+// ---------------------------------------------------------------------------
+
+class _TreeNodeRow extends StatelessWidget {
+  const _TreeNodeRow({
     required this.name,
     required this.depth,
-    required this.findings,
+    required this.nameColor,
+    required this.isItalic,
+    required this.decision,
     required this.isFocused,
-    required this.hasDescendantFindings,
-    this.onTap,
+    required this.onTap,
+    required this.onSecondaryTap,
   });
 
   final String name;
   final int depth;
-  final List<RationalizeFinding> findings;
+  final Color? nameColor;
+  final bool isItalic;
+  final bool? decision; // true=accepted, false=rejected, null=unresolved
   final bool isFocused;
-  final bool hasDescendantFindings;
   final VoidCallback? onTap;
+  final void Function(Offset)? onSecondaryTap;
 
   @override
   Widget build(BuildContext context) {
+    final textColor = nameColor ?? _kText;
+    final folderIconColor = nameColor ?? const Color(0xFF4FC1FF);
+
     return GestureDetector(
       onTap: onTap,
+      onSecondaryTapUp: onSecondaryTap != null
+          ? (d) => onSecondaryTap!(d.globalPosition)
+          : null,
       child: Container(
         height: 26,
-        color: isFocused ? _kBlue.withValues(alpha: 0.15) : Colors.transparent,
-        padding: EdgeInsets.only(left: 12.0 + depth * 16),
+        color:
+            isFocused ? _kBlue.withValues(alpha: 0.2) : Colors.transparent,
+        padding: EdgeInsets.only(left: 12.0 + depth * 16.0, right: 8),
         child: Row(
           children: [
-            const Icon(Icons.folder, size: 14, color: Color(0xFF4FC1FF)),
+            Icon(Icons.folder, size: 14, color: folderIconColor),
             const SizedBox(width: 6),
             Expanded(
               child: Text(
                 name,
-                style:
-                    const TextStyle(color: _kText, fontSize: 12),
+                style: TextStyle(
+                  color: textColor,
+                  fontSize: 12,
+                  fontStyle:
+                      isItalic ? FontStyle.italic : FontStyle.normal,
+                ),
                 overflow: TextOverflow.ellipsis,
               ),
             ),
-            if (hasDescendantFindings && findings.isEmpty)
-              const Padding(
-                padding: EdgeInsets.only(right: 4),
-                child: Text('↓',
-                    style: TextStyle(
-                        color: _kSubtext, fontSize: 10)),
-              ),
-            // Badges for findings on this node
-            for (final f in findings)
+            if (decision != null)
               Padding(
-                padding: const EdgeInsets.only(right: 3),
-                child: _FindingTypeBadge(type: f.findingType, small: true),
+                padding: const EdgeInsets.only(left: 4),
+                child: Icon(
+                  decision! ? Icons.check_circle : Icons.cancel,
+                  size: 12,
+                  color: decision! ? _kSuccessBadge : _kSubtext,
+                ),
               ),
-            const SizedBox(width: 8),
           ],
         ),
       ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// _DetailDrawerOverlay — slides in from the right over both panels
+// ---------------------------------------------------------------------------
+
+class _DetailDrawerOverlay extends StatefulWidget {
+  const _DetailDrawerOverlay({
+    required this.finding,
+    required this.decision,
+    required this.destinationOverride,
+    required this.onAccept,
+    required this.onReject,
+    required this.onClose,
+    required this.onDestinationChanged,
+  });
+
+  final RationalizeFinding finding;
+  final bool? decision;
+  final String? destinationOverride;
+  final VoidCallback onAccept;
+  final VoidCallback onReject;
+  final VoidCallback onClose;
+  final void Function(String) onDestinationChanged;
+
+  @override
+  State<_DetailDrawerOverlay> createState() => _DetailDrawerOverlayState();
+}
+
+class _DetailDrawerOverlayState extends State<_DetailDrawerOverlay> {
+  late final TextEditingController _nameController;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(
+        text: _suggestedName(widget.finding, widget.destinationOverride));
+  }
+
+  @override
+  void didUpdateWidget(_DetailDrawerOverlay old) {
+    super.didUpdateWidget(old);
+    if (old.finding.id != widget.finding.id) {
+      _nameController.text =
+          _suggestedName(widget.finding, widget.destinationOverride);
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  static String _suggestedName(
+      RationalizeFinding f, String? override) {
+    if (override != null && override.isNotEmpty) {
+      return override.split('/').last;
+    }
+    final dest = f.destination ?? f.absoluteDestination ?? '';
+    return dest.isNotEmpty ? dest.split('/').last : '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final f = widget.finding;
+    final isRename = f.action == FindingAction.rename;
+    final accepted = widget.decision == true;
+    final rejected = widget.decision == false;
+
+    return Positioned(
+      top: 0,
+      right: 0,
+      bottom: 0,
+      width: 340,
+      child: Container(
+        decoration: BoxDecoration(
+          color: _kPanelBg,
+          border: Border(left: BorderSide(color: _kDivider)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.45),
+              blurRadius: 16,
+              offset: const Offset(-4, 0),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header
+            Container(
+              height: 44,
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              decoration:
+                  BoxDecoration(border: Border(bottom: BorderSide(color: _kDivider))),
+              child: Row(
+                children: [
+                  _FindingTypeBadge(type: f.findingType),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      f.displayName,
+                      style: const TextStyle(
+                          color: _kText,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close, size: 16, color: _kSubtext),
+                    onPressed: widget.onClose,
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ],
+              ),
+            ),
+
+            // Body
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Type + severity row
+                    Row(
+                      children: [
+                        Text(
+                          f.severity == FindingSeverity.issue
+                              ? 'Issue'
+                              : 'Warning',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: f.severity == FindingSeverity.issue
+                                ? _kIssueBadge
+                                : _kWarningBadge,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(width: 6),
+                        Text(f.findingType.label,
+                            style:
+                                const TextStyle(color: _kSubtext, fontSize: 11)),
+                      ],
+                    ),
+                    const SizedBox(height: 14),
+
+                    // Path
+                    _DrawerField(label: 'Current path', value: f.path),
+                    const SizedBox(height: 10),
+
+                    // Proposed action
+                    _DrawerField(
+                        label: 'Proposed action',
+                        value: _actionDescription(f)),
+
+                    // Rename field
+                    if (isRename) ...[
+                      const SizedBox(height: 12),
+                      const Text('New name',
+                          style: TextStyle(
+                              color: _kSubtext,
+                              fontSize: 11,
+                              fontWeight: FontWeight.w500)),
+                      const SizedBox(height: 4),
+                      TextField(
+                        controller: _nameController,
+                        style: const TextStyle(color: _kText, fontSize: 12),
+                        onChanged: widget.onDestinationChanged,
+                        decoration: InputDecoration(
+                          isDense: true,
+                          contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 8, vertical: 8),
+                          filled: true,
+                          fillColor: const Color(0xFF3C3C3C),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(4),
+                            borderSide:
+                                const BorderSide(color: _kDivider),
+                          ),
+                          enabledBorder: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(4),
+                            borderSide:
+                                const BorderSide(color: _kDivider),
+                          ),
+                        ),
+                      ),
+                    ],
+
+                    // Inference basis
+                    if (f.inferenceBasis.isNotEmpty) ...[
+                      const SizedBox(height: 14),
+                      const Text('Why?',
+                          style: TextStyle(
+                              color: _kSubtext,
+                              fontSize: 11,
+                              fontWeight: FontWeight.w500)),
+                      const SizedBox(height: 4),
+                      Text(f.inferenceBasis,
+                          style: const TextStyle(
+                              color: _kText, fontSize: 12)),
+                    ],
+
+                    // Cascade indicator
+                    if (f.triggeredBy != null) ...[
+                      const SizedBox(height: 12),
+                      Row(
+                        children: const [
+                          Icon(Icons.account_tree,
+                              size: 12, color: _kSubtext),
+                          SizedBox(width: 4),
+                          Text('Cascaded from parent finding',
+                              style:
+                                  TextStyle(color: _kSubtext, fontSize: 11)),
+                        ],
+                      ),
+                    ],
+
+                    // Current decision status
+                    if (widget.decision != null) ...[
+                      const SizedBox(height: 12),
+                      Row(
+                        children: [
+                          Icon(
+                            accepted ? Icons.check_circle : Icons.cancel,
+                            size: 12,
+                            color:
+                                accepted ? _kSuccessBadge : _kSubtext,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            accepted ? 'Accepted' : 'Rejected',
+                            style: TextStyle(
+                              fontSize: 11,
+                              color:
+                                  accepted ? _kSuccessBadge : _kSubtext,
+                            ),
+                          ),
+                          const SizedBox(width: 4),
+                          Text('— tap to change',
+                              style: const TextStyle(
+                                  color: _kSubtext, fontSize: 11)),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+
+            // Accept / Reject buttons
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                  border: Border(top: BorderSide(color: _kDivider))),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor:
+                            rejected ? _kIssueBadge : _kSubtext,
+                        side: BorderSide(
+                            color:
+                                rejected ? _kIssueBadge : _kDivider),
+                      ),
+                      onPressed: widget.onReject,
+                      child: const Text('Reject',
+                          style: TextStyle(fontSize: 13)),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor:
+                            accepted ? _kSuccessBadge : _kBlue,
+                        foregroundColor: Colors.white,
+                      ),
+                      onPressed: widget.onAccept,
+                      child: const Text('Accept',
+                          style: TextStyle(fontSize: 13)),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _actionDescription(RationalizeFinding f) => switch (f.action) {
+        FindingAction.remove => 'Remove → Quarantine',
+        FindingAction.rename => () {
+            final dest = widget.destinationOverride ?? f.destination ?? '';
+            final name =
+                dest.isNotEmpty ? dest.split('/').last : '(suggested name)';
+            return 'Rename to "$name"';
+          }(),
+        FindingAction.move => () {
+            final dest = widget.destinationOverride ?? f.destination ?? '';
+            return 'Move to $dest';
+          }(),
+      };
+}
+
+// ---------------------------------------------------------------------------
+// _DrawerField — labelled text field in the detail drawer
+// ---------------------------------------------------------------------------
+
+class _DrawerField extends StatelessWidget {
+  const _DrawerField({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label,
+            style: const TextStyle(
+                color: _kSubtext,
+                fontSize: 11,
+                fontWeight: FontWeight.w500)),
+        const SizedBox(height: 2),
+        Text(value, style: const TextStyle(color: _kText, fontSize: 12)),
+      ],
     );
   }
 }
@@ -1309,15 +1300,13 @@ class _TreeRow extends StatelessWidget {
 
 class _BottomBar extends StatelessWidget {
   const _BottomBar({
-    required this.selectedCount,
-    required this.totalVisible,
-    required this.onPreview,
+    required this.accepted,
+    required this.unresolved,
     required this.onApply,
   });
 
-  final int selectedCount;
-  final int totalVisible;
-  final VoidCallback? onPreview;
+  final int accepted;
+  final int unresolved;
   final VoidCallback? onApply;
 
   @override
@@ -1325,38 +1314,39 @@ class _BottomBar extends StatelessWidget {
     return Container(
       height: 44,
       color: _kPanelBg,
-      padding: const EdgeInsets.symmetric(horizontal: 12),
+      padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Row(
         children: [
           Text(
-            selectedCount > 0
-                ? '$selectedCount of $totalVisible selected'
-                : '$totalVisible finding${totalVisible != 1 ? 's' : ''}',
-            style: const TextStyle(color: _kSubtext, fontSize: 12),
+            '$accepted accepted',
+            style: TextStyle(
+              color: accepted > 0 ? _kSuccessBadge : _kSubtext,
+              fontSize: 12,
+            ),
           ),
+          if (unresolved > 0) ...[
+            const Text(' · ',
+                style: TextStyle(color: _kSubtext, fontSize: 12)),
+            Text('$unresolved unresolved',
+                style:
+                    const TextStyle(color: _kSubtext, fontSize: 12)),
+          ],
           const Spacer(),
-          TextButton(
-            style: TextButton.styleFrom(foregroundColor: _kText),
-            onPressed: onPreview,
-            child: const Text('Preview Changes',
-                style: TextStyle(fontSize: 12)),
-          ),
-          const SizedBox(width: 8),
           ElevatedButton(
             style: ElevatedButton.styleFrom(
               backgroundColor:
                   onApply != null ? _kBlue : _kDivider,
               foregroundColor: Colors.white,
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+              padding: const EdgeInsets.symmetric(
+                  horizontal: 16, vertical: 8),
               minimumSize: Size.zero,
               tapTargetSize: MaterialTapTargetSize.shrinkWrap,
             ),
             onPressed: onApply,
             child: Text(
-              selectedCount > 0
-                  ? 'Apply Selected ($selectedCount)'
-                  : 'Apply Selected',
+              accepted > 0
+                  ? 'Apply $accepted Change${accepted != 1 ? 's' : ''}'
+                  : 'Apply Changes',
               style: const TextStyle(fontSize: 12),
             ),
           ),
@@ -1367,111 +1357,32 @@ class _BottomBar extends StatelessWidget {
 }
 
 // ---------------------------------------------------------------------------
-// _PreviewRow
-// ---------------------------------------------------------------------------
-
-class _PreviewRow extends StatelessWidget {
-  const _PreviewRow({
-    required this.finding,
-    required this.effectiveDestination,
-  });
-
-  final RationalizeFinding finding;
-  final String effectiveDestination;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      margin: const EdgeInsets.only(bottom: 8),
-      padding: const EdgeInsets.all(10),
-      decoration: BoxDecoration(
-        color: _kPanelBg,
-        borderRadius: BorderRadius.circular(6),
-        border: Border.all(color: _kDivider),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _FindingTypeBadge(type: finding.findingType),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(finding.displayName,
-                    style: const TextStyle(
-                        color: _kText,
-                        fontSize: 13,
-                        fontWeight: FontWeight.w500)),
-                const SizedBox(height: 2),
-                Text(
-                  _actionSummary,
-                  style:
-                      const TextStyle(color: _kSubtext, fontSize: 11),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  String get _actionSummary {
-    switch (finding.action) {
-      case FindingAction.remove:
-        return '→ Move to quarantine';
-      case FindingAction.rename:
-        final name = effectiveDestination.split('/').last;
-        return '→ Rename to "$name"';
-      case FindingAction.move:
-        return '→ Move to $effectiveDestination';
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
 // _FindingTypeBadge
 // ---------------------------------------------------------------------------
 
 class _FindingTypeBadge extends StatelessWidget {
-  const _FindingTypeBadge({required this.type, this.small = false});
+  const _FindingTypeBadge({required this.type});
 
   final FindingType type;
-  final bool small;
 
-  Color get _color {
-    switch (type) {
-      case FindingType.emptyFolder:
-        return _kIssueBadge;
-      case FindingType.namingInconsistency:
-        return _kIssueBadge;
-      case FindingType.misplacedFile:
-        return _kWarningBadge;
-      case FindingType.excessiveNesting:
-        return _kWarningBadge;
-    }
-  }
+  Color get _color => switch (type) {
+        FindingType.emptyFolder => _kIssueBadge,
+        FindingType.namingInconsistency => _kIssueBadge,
+        FindingType.misplacedFile => _kWarningBadge,
+        FindingType.excessiveNesting => _kWarningBadge,
+      };
 
-  String get _label {
-    switch (type) {
-      case FindingType.emptyFolder:
-        return small ? 'E' : 'empty';
-      case FindingType.namingInconsistency:
-        return small ? 'N' : 'naming';
-      case FindingType.misplacedFile:
-        return small ? 'M' : 'misplaced';
-      case FindingType.excessiveNesting:
-        return small ? 'D' : 'nesting';
-    }
-  }
+  String get _label => switch (type) {
+        FindingType.emptyFolder => 'empty',
+        FindingType.namingInconsistency => 'naming',
+        FindingType.misplacedFile => 'misplaced',
+        FindingType.excessiveNesting => 'nesting',
+      };
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: EdgeInsets.symmetric(
-          horizontal: small ? 4 : 6,
-          vertical: small ? 1 : 2),
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
       decoration: BoxDecoration(
         color: _color.withValues(alpha: 0.2),
         borderRadius: BorderRadius.circular(3),
@@ -1481,57 +1392,8 @@ class _FindingTypeBadge extends StatelessWidget {
         _label,
         style: TextStyle(
           color: _color,
-          fontSize: small ? 9 : 10,
+          fontSize: 10,
           fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// _TriStateCheckbox — custom visible checkbox for dark backgrounds
-// ---------------------------------------------------------------------------
-
-class _TriStateCheckbox extends StatelessWidget {
-  const _TriStateCheckbox({
-    required this.checked,
-    required this.indeterminate,
-    required this.onTap,
-  });
-
-  final bool checked;
-  final bool indeterminate;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        width: 16,
-        height: 16,
-        decoration: BoxDecoration(
-          color: (checked || indeterminate) ? _kBlue : Colors.transparent,
-          borderRadius: BorderRadius.circular(3),
-          border: Border.all(
-            color: (checked || indeterminate)
-                ? _kBlue
-                : const Color(0xFF6E6E6E),
-            width: 1.5,
-          ),
-        ),
-        child: Center(
-          child: indeterminate
-              ? Container(
-                  width: 8,
-                  height: 2,
-                  color: Colors.white,
-                )
-              : checked
-                  ? const Icon(Icons.check,
-                      size: 11, color: Colors.white)
-                  : null,
         ),
       ),
     );


### PR DESCRIPTION
## Summary

Implements the redesigned Rationalize screen per [design-iteration-3-rationalize-redesign.md](docs/design-iteration-3-rationalize-redesign.md) (merged in #54).

- **Two side-by-side panels** replace the findings list + annotated tree layout
  - *Original* (left): full tree of finding paths, colour-coded by action — red=remove, orange=rename, blue=move — using named `_kRemoveColor` / `_kRenameColor` / `_kMoveColor` constants for easy palette tuning
  - *Target* (right): computed target state — removed folders absent, accepted renames/moves shown in green italic (`_kRenameTargetColor`)
- **Detail drawer** (single click on any flagged row): finding type, severity, path, proposed action, inference basis, editable rename field, Accept / Reject buttons with equal weight and no default
- **Right-click context menu**: Accept/Reject shortcuts on any flagged row; user-initiated "mark for removal" stubbed (Issue #46, future iteration)
- **Accept/Reject state model** replaces checkbox selection: `Map<String, bool> _decisions`; unresolved findings are left untouched at execution time
- **Previewing phase removed**: right panel serves as the live before/after preview
- All 42 tests passing

## Test plan

- Verify all 42 tests pass (`flutter test`)
- Run against `test_corpus/rationalize` with a real Rust build (`make check`)
- Visual review: open a folder with findings, confirm left panel shows colour-coded rows, right panel updates as you Accept/Reject in the drawer

🤖 Generated with [Claude Code](https://claude.ai/claude-code)