### PR TITLE
Process: PR template + CONTRIBUTING.md — drafts until UI review

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- 1–3 bullet points describing what this PR does and why. -->
+
+## Test plan
+
+<!-- Bulleted checklist of what to verify. -->
+
+- [ ] All Flutter tests pass (`flutter test`)
+- [ ] All Rust tests pass (`cargo test --manifest-path rust_core/Cargo.toml`)
+
+## UI review
+
+<!-- PRs start as drafts. Convert to Ready for Review only after UI review is complete. -->
+
+- [ ] Ran the app against a real folder and verified the affected screens behave as expected
+- [ ] No regressions observed in adjacent screens
+
+---
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to FileSteward
+
+## Roles
+
+| Role | GitHub account | Responsibility |
+|---|---|---|
+| Dev lead | KarlJBorn | Product decisions, UI review, PR approval and merge |
+| Automation | SpringAgents | Opens PRs, posts review comments on behalf of Claude Code |
+
+## Branch model
+
+- `main` is protected. No direct pushes.
+- All work happens on feature branches, merged via PR.
+- Branch naming: `iter3/short-description`, `design/topic`, `fix/topic`, `process/topic`.
+
+## Development workflow
+
+1. **Design first** — significant changes require a design doc in `docs/` before implementation begins. Open a design PR, get it merged, then implement.
+2. **Implement in a branch** — keep changes focused. One concern per PR.
+3. **Tests pass** — `make check` (Rust build + Flutter tests) must be green before opening a PR.
+4. **Open as draft** — all PRs open as drafts. A draft signals "not yet reviewed."
+5. **UI review** — run the app against a real folder and verify the affected screens. This is a required step before a PR is ready to merge.
+6. **Convert to ready** — once UI review passes, convert the draft to ready for review.
+7. **Approve and merge** — KarlJBorn approves and merges in the browser.
+
+## Why PRs start as drafts
+
+Code passing tests is necessary but not sufficient. FileSteward operates on real user data. UI review catches issues that tests cannot — confusing flows, missing edge case handling, regressions in adjacent screens. No PR should be merged without someone having run the app.
+
+## Design-doc-before-code
+
+For any change that:
+- Affects the execution model (how files are modified)
+- Changes a user-facing flow (new phase, new screen, new interaction)
+- Introduces a new domain concept
+
+...write a design doc in `docs/` first. Capture the decision, the alternatives considered, and the open questions. Get it merged. Then implement.
+
+This practice exists because real-data testing has repeatedly revealed that the "obvious" implementation is wrong in ways that only become clear when you describe the full system behavior in prose.
+
+## Commit messages
+
+- First line: short imperative summary (≤72 chars), prefixed with scope: `Iter 3:`, `Fix:`, `Design:`, `Process:`
+- Body: what and why, not how
+- Co-authored-by line for Claude Code commits
+
+## Commands
+
+```bash
+# Build Rust core
+make rust-build
+
+# Run the app (macOS)
+make flutter-run
+
+# Run all tests
+make check
+
+# Flutter tests only
+flutter test
+
+# Rust tests only
+cargo test --manifest-path rust_core/Cargo.toml
+```


### PR DESCRIPTION
## Summary

- Adds `.github/pull_request_template.md` — all new PRs pre-populate with a summary, test plan, and UI review checklist
- Adds `CONTRIBUTING.md` — documents the full development workflow: roles, branch model, design-doc-before-code, draft PR rule, commit conventions

## The rule

All PRs open as drafts. A draft may only be converted to ready-for-review after the UI has been run and the affected screens verified. This was prompted by PR #66 being opened as ready-for-review before any UI review had occurred.

## Test plan

- [ ] Open a new PR and verify the template pre-populates correctly
- [ ] No Flutter/Rust code changes — no test run required

## UI review

- [ ] N/A — process/docs change only

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)