### PR TITLE
fix(#36, #37): inherit selected folder; disable Rationalize until folder chosen

### DIFF
--- a/lib/app_version.dart
+++ b/lib/app_version.dart
@@ -2,4 +2,4 @@
 ///
 /// Keep in sync with the `version` field in pubspec.yaml.
 /// Format: MAJOR.MINOR.PATCH (no build number).
-const String kAppVersion = '0.3.1';
+const String kAppVersion = '0.3.2';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -694,11 +694,13 @@ class _FileStewardHomePageState extends State<FileStewardHomePage> {
             ),
             const SizedBox(height: 8),
             ElevatedButton.icon(
-              onPressed: (_isInventoryRunning || _isRunning)
+              onPressed: (_isInventoryRunning || _isRunning || folderPath == null)
                   ? null
                   : () => Navigator.of(context).push(
                         MaterialPageRoute<void>(
-                          builder: (_) => const RationalizeScreen(),
+                          builder: (_) => RationalizeScreen(
+                            initialFolder: folderPath,
+                          ),
                         ),
                       ),
               style: ElevatedButton.styleFrom(

--- a/lib/rationalize_screen.dart
+++ b/lib/rationalize_screen.dart
@@ -76,7 +76,10 @@ class _TreeNode {
 // ---------------------------------------------------------------------------
 
 class RationalizeScreen extends StatefulWidget {
-  const RationalizeScreen({super.key});
+  const RationalizeScreen({super.key, this.initialFolder});
+
+  /// When provided, skips the folder picker and begins scanning immediately.
+  final String? initialFolder;
 
   @override
   State<RationalizeScreen> createState() => _RationalizeScreenState();
@@ -302,10 +305,18 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
   // Scan
   // ---------------------------------------------------------------------------
 
-  Future<void> _pickFolderAndScan() async {
-    final path = await getDirectoryPath();
-    if (path == null || path.isEmpty || !mounted) return;
+  @override
+  void initState() {
+    super.initState();
+    final folder = widget.initialFolder;
+    if (folder != null && folder.isNotEmpty) {
+      // Defer until after first frame so the widget tree is mounted.
+      WidgetsBinding.instance.addPostFrameCallback((_) => _startScan(folder));
+    }
+  }
 
+  /// Begin a scan for [path], resetting all state first.
+  Future<void> _startScan(String path) async {
     setState(() {
       _selectedFolder = path;
       _phase = _Phase.scanning;
@@ -352,6 +363,13 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
       }
     }
   }
+
+  Future<void> _pickFolderAndScan() async {
+    final path = await getDirectoryPath();
+    if (path == null || path.isEmpty || !mounted) return;
+    await _startScan(path);
+  }
+
 
   // ---------------------------------------------------------------------------
   // Build

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: filesteward
 description: A macOS-first FileSteward prototype.
 publish_to: 'none'
-version: 0.3.1+1
+version: 0.3.2+1
 
 environment:
   sdk: ^3.9.0

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -10,7 +10,7 @@ void main() {
 
     // Splash screen should be visible first.
     expect(find.text('FileSteward'), findsOneWidget);
-    expect(find.text('v0.3.1'), findsOneWidget);
+    expect(find.text('v0.3.2'), findsOneWidget);
 
     // Advance past the splash timer and settle the navigation animation.
     await tester.pump(const Duration(milliseconds: 1500));


### PR DESCRIPTION
## Summary
- **#36** — `RationalizeScreen` now accepts `initialFolder`. When provided, scanning begins immediately on open — no redundant folder picker.
- **#37** — "Rationalize Folder…" button is disabled until a folder is selected on the home screen. The selected folder is passed through automatically.

## Flow before
1. Select folder on home screen
2. Tap Rationalize Folder — opens picker again, must re-select same folder
3. Button was always enabled even with no folder selected

## Flow after
1. Select folder on home screen — Rationalize button activates
2. Tap Rationalize Folder — scan begins immediately with the selected folder

## Test plan
- [ ] Launch app — confirm Rationalize Folder button is disabled
- [ ] Select a folder — confirm button enables
- [ ] Tap Rationalize Folder — confirm scan starts immediately, no picker shown
- [ ] Confirm splash shows v0.3.2

## UI review required before merge

Closes #36
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)