### PR TITLE
fix(#46): right-click folders only; suppress menu on file rows

### DIFF
--- a/lib/rationalize_screen.dart
+++ b/lib/rationalize_screen.dart
@@ -473,6 +473,9 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
   // ---------------------------------------------------------------------------
 
   void _showContextMenu(BuildContext ctx, Offset pos, _TreeNode node) {
+    // Files don't have folder-level actions.
+    if (node.isFile) return;
+
     final finding = node.finding;
     final isUserMarked = _userRemovedPaths.containsKey(node.relativePath);
     final decision = finding != null ? _decisions[finding.id] : null;


### PR DESCRIPTION
## Summary

Right-clicking a file row previously showed "Mark subtree for removal" — which makes no sense for a file. One-line guard added: `if (node.isFile) return`.

The existing folder context menu already covers the core of #46:
- Any folder (engine-found or clean) → right-click → mark/unmark for removal
- Engine-found folders additionally show Accept / Reject

Rename and move for manually-specified clean folders are deferred to iteration 4 (#74).

## Test plan
- [ ] Right-click a file row — no menu appears
- [ ] Right-click a clean folder — "Mark subtree for removal" appears
- [ ] Right-click an engine-found folder — Accept / Reject + mark options appear
- [ ] Splash shows v0.3.4

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)