### PR TITLE
feat(#41): bulk reject/accept all findings in a folder subtree

### DIFF
--- a/lib/rationalize_screen.dart
+++ b/lib/rationalize_screen.dart
@@ -295,6 +295,28 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
   void _unmarkForRemoval(String relativePath) =>
       setState(() => _userRemovedPaths.remove(relativePath));
 
+  /// Returns all engine findings whose path falls under [prefix].
+  List<RationalizeFinding> _findingsUnder(String prefix) {
+    final p = _payload;
+    if (p == null) return [];
+    return p.findings.where((f) =>
+        f.path == prefix || f.path.startsWith('$prefix/')).toList();
+  }
+
+  void _rejectSubtree(String prefix) => setState(() {
+        for (final f in _findingsUnder(prefix)) {
+          _decisions[f.id] = false;
+        }
+        _drawerFindingId = null;
+      });
+
+  void _acceptSubtree(String prefix) => setState(() {
+        for (final f in _findingsUnder(prefix)) {
+          _decisions[f.id] = true;
+        }
+        _drawerFindingId = null;
+      });
+
   void _openDrawer(String id) => setState(() => _drawerFindingId = id);
   void _closeDrawer() => setState(() => _drawerFindingId = null);
 
@@ -480,6 +502,12 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
     final isUserMarked = _userRemovedPaths.containsKey(node.relativePath);
     final decision = finding != null ? _decisions[finding.id] : null;
 
+    final subtreeFindings = _findingsUnder(node.relativePath);
+    final hasActiveInSubtree =
+        subtreeFindings.any((f) => _decisions[f.id] != false);
+    final hasRejectedInSubtree =
+        subtreeFindings.any((f) => _decisions[f.id] == false);
+
     showMenu<String>(
       context: ctx,
       position: RelativeRect.fromLTRB(pos.dx, pos.dy, pos.dx + 1, pos.dy + 1),
@@ -515,6 +543,25 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
             style: const TextStyle(fontSize: 13),
           ),
         ),
+        if (subtreeFindings.length > 1) ...[
+          const PopupMenuDivider(),
+          if (hasActiveInSubtree)
+            PopupMenuItem(
+              value: 'reject_subtree',
+              child: Text(
+                'Reject all findings in subtree (${subtreeFindings.length})',
+                style: const TextStyle(fontSize: 13, color: _kSubtext),
+              ),
+            ),
+          if (hasRejectedInSubtree)
+            PopupMenuItem(
+              value: 'accept_subtree',
+              child: Text(
+                'Accept all findings in subtree (${subtreeFindings.length})',
+                style: const TextStyle(fontSize: 13),
+              ),
+            ),
+        ],
       ],
     ).then((value) {
       if (value == null) return;
@@ -524,6 +571,8 @@ class _RationalizeScreenState extends State<RationalizeScreen> {
         _markForRemoval(node.relativePath, node.absolutePath);
       }
       if (value == 'unmark') _unmarkForRemoval(node.relativePath);
+      if (value == 'reject_subtree') _rejectSubtree(node.relativePath);
+      if (value == 'accept_subtree') _acceptSubtree(node.relativePath);
     });
   }
 


### PR DESCRIPTION
## Summary

Right-clicking any folder with 2+ findings in its subtree now shows:
- **Reject all findings in subtree (N)** — when there are active findings to dismiss
- **Accept all findings in subtree (N)** — when there are rejected findings to restore

Only appears when `subtreeFindings.length > 1` — single-finding and clean folders get no extra menu items.

## Test plan
- [ ] Scan a folder with multiple findings (e.g. `Born_Family_2000_01_24`)
- [ ] Right-click a parent folder containing several findings — bulk reject option appears with count
- [ ] Select it — all descendant findings dim and disappear from Target panel
- [ ] Right-click same folder — bulk accept option appears
- [ ] Select it — findings restored
- [ ] Right-click a clean folder or single-finding folder — no bulk options shown
- [ ] Splash shows v0.3.5

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)