### PR TITLE
docs: close out Iteration 4 — product-definition and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,20 +98,14 @@ It is **not** a bulk-delete tool; it is an analysis and decision-support tool. E
 - Splash screen with version number
 - Draft PR convention + CONTRIBUTING.md
 
-### Iteration 4 — Duplicate File Detection *(current)*
-**Goal:** Complete the Maintain workflow by adding content-based duplicate detection and file-level resolution within a single directory tree.
-
-**What "done" looks like:**
-> "I scanned My Photos. FileSteward found 47 duplicate files across 12 groups. I reviewed each group, kept the best copy, removed the rest. Built and swapped."
-
-**Scope:**
-- Wire SHA-256 hashing into the rationalize scan (infrastructure exists in `main.rs`, needs porting to `rationalize.rs`)
-- Emit `duplicate_file` findings grouping files by hash
-- Show duplicate groups in the rationalize UI; right-click file actions (keep / remove this copy)
-- Build step already handles file skips via skip table — no engine changes needed there
-- Update `docs/product-definition.md` to reflect Maintain-first approach and two-app decision
-
-**Out of scope:** Consolidate, library restructure (#79), near-duplicate similarity detection, rules engine.
+### Iteration 4 — Duplicate File Detection ✅ Complete (v0.4.0)
+- SHA-256 hashing wired into the rationalize scan
+- Penalty-based duplicate ranker: auto-resolves clear cases, flags ambiguous groups for user decision
+- Duplicate resolution panel below the tree: auto-resolved summary + keeper selection for ambiguous groups
+- Apply blocked until all ambiguous groups resolved
+- Build step omits non-kept duplicate copies via `duplicate_removals`
+- Collapsible/expandable folder nodes in both tree panels (depth ≥ 2 starts collapsed)
+- `docs/product-definition.md` updated to reflect Maintain-first approach and two-app vision
 
 ### Iteration 5 — Consolidate App (first version)
 **Goal:** FileSteward Consolidate v1. Multiple source directories → one canonical output.

--- a/docs/product-definition.md
+++ b/docs/product-definition.md
@@ -61,8 +61,18 @@ Takes a single directory, analyses its structure, and produces a rationalized ve
 5. User reviews build stats; confirms swap
 6. Source renamed to `source.OLD`; copy renamed to `source`
 
-### Current status
-**This is what FileSteward builds today.** The rationalize screen, copy-then-swap, and naming engine are all Maintain.
+### Current status — Iteration 4 complete (v0.4.0)
+**This is what FileSteward builds today.** The rationalize screen, copy-then-swap execution model, naming engine, and duplicate file resolution are all Maintain.
+
+Completed capabilities:
+- Side-by-side Original / Target directory tree with collapse/expand
+- Structural findings: empty folders, naming inconsistencies, excessive nesting, misplaced files
+- SHA-256 duplicate detection: groups identical files by hash
+- Penalty-based ranker: auto-resolves most duplicate groups; flags ambiguous groups for user decision
+- Duplicate resolution panel: shows auto-resolved summary + per-group keeper selection for ambiguous cases
+- Apply is blocked until all ambiguous groups are resolved
+- Build step omits non-kept duplicate copies from the rationalized output
+- Atomic swap: source renamed to `.OLD`; rationalized copy takes source name
 
 ---
 
@@ -70,14 +80,17 @@ Takes a single directory, analyses its structure, and produces a rationalized ve
 
 Both products run on the same Rust engine:
 
-| Capability | Consolidate | Maintain |
-|---|---|---|
-| Recursive directory walk | ✓ | ✓ |
-| SHA-256 file fingerprinting | ✓ | ✓ |
-| Duplicate detection | ✓ | ✓ |
-| Naming convention analysis | — | ✓ |
-| Build (copy with transformations) | ✓ | ✓ |
-| Swap | — | ✓ |
+| Capability | Consolidate | Maintain | Status |
+|---|---|---|---|
+| Recursive directory walk | ✓ | ✓ | ✅ Done |
+| SHA-256 file fingerprinting | ✓ | ✓ | ✅ Done |
+| Exact duplicate detection (group by hash) | ✓ | ✓ | ✅ Done |
+| Penalty-based duplicate ranker | ✓ | ✓ | ✅ Done |
+| Naming convention analysis | — | ✓ | ✅ Done |
+| Build (copy with transformations) | ✓ | ✓ | ✅ Done |
+| Swap | — | ✓ | ✅ Done |
+| Multi-source walk + fold-in | ✓ | — | Iteration 5 |
+| Rust library restructure (#79) | ✓ | ✓ | Iteration 5 |
 
 ---
 
@@ -95,4 +108,8 @@ FileSteward Consolidate and FileSteward Maintain ship separately, sharing the Ru
 
 ## What this means for the roadmap
 
-Iteration 4 should not start until this document is agreed. The main screen redesign (#74), multi-folder selection (#38), and all consolidation work must be designed against this definition — not the original iteration plan, which predates this distinction.
+**Iteration 4 is complete.** Maintain v0.4.0 ships with full duplicate detection and resolution.
+
+**Iteration 5 — Consolidate v1** is next. The main screen will need a mode selector or a second
+entry point. Multi-folder selection (#38), the shared Rust library restructure (#79), and the
+Consolidate engine are all in scope. Design those features against this definition.


### PR DESCRIPTION
## Summary
- `docs/product-definition.md`: marks Maintain I4 complete (v0.4.0), lists all shipped capabilities, adds status column to shared foundation table, replaces the stale "Iteration 4 should not start" paragraph with a forward pointer to Iteration 5
- `CLAUDE.md`: marks Iteration 4 complete with the full list of delivered items; Iteration 5 — Consolidate is now the active iteration

## Test plan
- [ ] Docs-only change — no code affected, no tests to run
- [ ] Read through both files and confirm they accurately reflect what shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)