### PR TITLE
Rust: central session registry for Consolidate (#96)

### DIFF
--- a/rust_core/src/consolidate.rs
+++ b/rust_core/src/consolidate.rs
@@ -1,6 +1,8 @@
-/// FileSteward Consolidate engine — multi-source hash diff.
+/// FileSteward Consolidate engine — multi-source hash diff + session registry.
 ///
-/// Reads a JSON command from stdin:
+/// Reads a JSON command from stdin. Supported commands:
+///
+/// **consolidate_scan** — walk sources, diff secondaries against primary:
 /// ```json
 /// {
 ///   "command": "consolidate_scan",
@@ -9,8 +11,22 @@
 /// }
 /// ```
 ///
-/// Streams progress events to stdout (NDJSON), then emits a final
-/// `consolidate_scan_complete` event with the unique files per secondary.
+/// **consolidate_build** — copy approved unique files into the target:
+/// ```json
+/// {
+///   "command": "consolidate_build",
+///   "session_id": "2026-04-01T15-00-00",
+///   "target": "/path/to/target",
+///   "fold_ins": [
+///     { "source_root": "/path/to/secondary_1", "relative_path": "photos/beach.jpg" }
+///   ]
+/// }
+/// ```
+///
+/// **consolidate_finalize** — mark a session as finalized in the registry:
+/// ```json
+/// { "command": "consolidate_finalize", "session_id": "2026-04-01T15-00-00" }
+/// ```
 use hex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -18,16 +34,91 @@ use std::collections::HashSet;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 // ---------------------------------------------------------------------------
-// IPC types
+// Registry types (~/.filesteward/sessions.json)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum SessionStatus {
+    InProgress,
+    Complete,
+    Finalized,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct SecondaryRecord {
+    path: String,
+    analyzed: String,
+    status: String,
+    files_folded_in: usize,
+    files_skipped: usize,
+    skipped: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct SessionRecord {
+    id: String,
+    created: String,
+    target: String,
+    primary: String,
+    status: String,
+    secondaries: Vec<SecondaryRecord>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Registry {
+    sessions: Vec<SessionRecord>,
+}
+
+// ---------------------------------------------------------------------------
+// IPC command types
 // ---------------------------------------------------------------------------
 
 #[derive(Deserialize)]
-struct ConsolidateScanCommand {
+#[serde(tag = "command", rename_all = "snake_case")]
+enum ConsolidateCommand {
+    ConsolidateScan(ScanCmd),
+    ConsolidateBuild(BuildCmd),
+    ConsolidateFinalize(FinalizeCmd),
+}
+
+#[derive(Deserialize)]
+struct ScanCmd {
     primary: String,
     secondaries: Vec<String>,
+    /// Optional: if provided, a new session is created/updated in the registry.
+    session_id: Option<String>,
+    target: Option<String>,
 }
+
+#[derive(Deserialize)]
+struct FoldIn {
+    source_root: String,
+    relative_path: String,
+    /// Relative paths within the secondary that were skipped by the user.
+    #[serde(default)]
+    skipped: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct BuildCmd {
+    session_id: String,
+    target: String,
+    fold_ins: Vec<FoldIn>,
+}
+
+#[derive(Deserialize)]
+struct FinalizeCmd {
+    session_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// IPC output types
+// ---------------------------------------------------------------------------
 
 #[derive(Serialize)]
 struct ConsolidateProgressEvent {
@@ -53,8 +144,25 @@ struct SecondaryResult {
 struct ConsolidateScanComplete {
     #[serde(rename = "type")]
     event_type: &'static str,
+    session_id: String,
     primary: String,
     secondaries: Vec<SecondaryResult>,
+}
+
+#[derive(Serialize)]
+struct ConsolidateBuildComplete {
+    #[serde(rename = "type")]
+    event_type: &'static str,
+    session_id: String,
+    target: String,
+    files_copied: usize,
+}
+
+#[derive(Serialize)]
+struct ConsolidateFinalizeComplete {
+    #[serde(rename = "type")]
+    event_type: &'static str,
+    session_id: String,
 }
 
 #[derive(Serialize)]
@@ -82,6 +190,103 @@ fn emit_error(message: &str) {
     });
 }
 
+fn now_iso() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Format as a sortable ISO-like string.
+    let dt = secs_to_iso(secs);
+    dt
+}
+
+fn secs_to_iso(secs: u64) -> String {
+    // Simple UTC formatter — avoids pulling in chrono.
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    let days = secs / 86400;
+    // Days since 1970-01-01 → year/month/day
+    let (y, mo, d) = days_to_ymd(days);
+    format!("{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z", y, mo, d, h, m, s)
+}
+
+fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
+    let mut y = 1970u64;
+    loop {
+        let dy = if is_leap(y) { 366 } else { 365 };
+        if days < dy {
+            break;
+        }
+        days -= dy;
+        y += 1;
+    }
+    let leap = is_leap(y);
+    let months = [31u64, if leap { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut mo = 1u64;
+    for dm in &months {
+        if days < *dm {
+            break;
+        }
+        days -= dm;
+        mo += 1;
+    }
+    (y, mo, days + 1)
+}
+
+fn is_leap(y: u64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+fn session_id_from_iso(iso: &str) -> String {
+    iso.replace(':', "-").replace('T', "T").trim_end_matches('Z').to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Registry read/write
+// ---------------------------------------------------------------------------
+
+fn registry_path() -> Option<PathBuf> {
+    // Allow tests (and CI) to redirect the registry to a temp location.
+    if let Ok(p) = std::env::var("FILESTEWARD_REGISTRY_PATH") {
+        return Some(PathBuf::from(p));
+    }
+    let home = std::env::var("HOME").ok()?;
+    Some(PathBuf::from(home).join(".filesteward").join("sessions.json"))
+}
+
+fn load_registry() -> Registry {
+    registry_path()
+        .and_then(|p| fs::read_to_string(&p).ok())
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or(Registry { sessions: vec![] })
+}
+
+fn save_registry(registry: &Registry) {
+    let Some(path) = registry_path() else { return };
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let tmp = path.with_extension("tmp");
+    if let Ok(json) = serde_json::to_string_pretty(registry) {
+        if fs::write(&tmp, &json).is_ok() {
+            let _ = fs::rename(&tmp, &path);
+        }
+    }
+}
+
+fn upsert_session(registry: &mut Registry, record: SessionRecord) {
+    if let Some(existing) = registry.sessions.iter_mut().find(|s| s.id == record.id) {
+        *existing = record;
+    } else {
+        registry.sessions.push(record);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hashing + directory walk
+// ---------------------------------------------------------------------------
+
 fn hash_file(path: &Path) -> Option<String> {
     let mut file = fs::File::open(path).ok()?;
     let mut hasher = Sha256::new();
@@ -96,8 +301,6 @@ fn hash_file(path: &Path) -> Option<String> {
     Some(hex::encode(hasher.finalize()))
 }
 
-/// Walk a directory tree and collect SHA-256 hashes of all files.
-/// Returns (hash_set, file_count). Errors on individual files are skipped.
 fn collect_hashes(root: &Path) -> HashSet<String> {
     let mut hashes = HashSet::new();
     collect_hashes_dir(root, root, &mut hashes);
@@ -129,12 +332,7 @@ fn collect_hashes_dir(root: &Path, current: &Path, hashes: &mut HashSet<String>)
     }
 }
 
-/// Walk a secondary directory, find files whose hash is not in `primary_hashes`.
-/// Emits progress events as it goes.
-fn diff_secondary(
-    secondary_root: &Path,
-    primary_hashes: &HashSet<String>,
-) -> Vec<UniqueFile> {
+fn diff_secondary(secondary_root: &Path, primary_hashes: &HashSet<String>) -> Vec<UniqueFile> {
     let mut unique = Vec::new();
     let mut files_scanned = 0usize;
     diff_secondary_dir(
@@ -175,8 +373,6 @@ fn diff_secondary_dir(
             diff_secondary_dir(root, &path, primary_hashes, unique, files_scanned, source_label);
         } else if metadata.is_file() {
             *files_scanned += 1;
-
-            // Emit progress every 50 files.
             if *files_scanned % 50 == 0 {
                 emit(&ConsolidateProgressEvent {
                     event_type: "consolidate_progress",
@@ -184,7 +380,6 @@ fn diff_secondary_dir(
                     files_scanned: *files_scanned,
                 });
             }
-
             if let Some(hash) = hash_file(&path) {
                 if !primary_hashes.contains(&hash) {
                     let relative_path = path
@@ -202,18 +397,15 @@ fn diff_secondary_dir(
 }
 
 // ---------------------------------------------------------------------------
-// Entry point
+// Command handlers
 // ---------------------------------------------------------------------------
 
-fn run(cmd: ConsolidateScanCommand) {
-    // Validate primary.
+fn handle_scan(cmd: ScanCmd) {
     let primary_path = PathBuf::from(&cmd.primary);
     if !primary_path.is_dir() {
         emit_error(&format!("Primary directory not found: {}", cmd.primary));
         return;
     }
-
-    // Validate secondaries (max 2).
     if cmd.secondaries.is_empty() || cmd.secondaries.len() > 2 {
         emit_error("Consolidate requires 1 or 2 secondary directories.");
         return;
@@ -225,7 +417,12 @@ fn run(cmd: ConsolidateScanCommand) {
         }
     }
 
-    // Build primary hash set — walk and hash everything.
+    // Assign session id — use provided or generate from current time.
+    let created = now_iso();
+    let session_id = cmd.session_id
+        .clone()
+        .unwrap_or_else(|| session_id_from_iso(&created));
+
     emit(&ConsolidateProgressEvent {
         event_type: "consolidate_progress",
         source: cmd.primary.clone(),
@@ -233,7 +430,6 @@ fn run(cmd: ConsolidateScanCommand) {
     });
     let primary_hashes = collect_hashes(&primary_path);
 
-    // Diff each secondary against the primary hash set.
     let mut secondary_results = Vec::new();
     for sec_path_str in &cmd.secondaries {
         let sec_path = PathBuf::from(sec_path_str);
@@ -244,10 +440,110 @@ fn run(cmd: ConsolidateScanCommand) {
         });
     }
 
+    // Write session to registry as in_progress.
+    let mut registry = load_registry();
+    upsert_session(&mut registry, SessionRecord {
+        id: session_id.clone(),
+        created,
+        target: cmd.target.clone().unwrap_or_default(),
+        primary: cmd.primary.clone(),
+        status: "in_progress".to_string(),
+        secondaries: vec![],
+    });
+    save_registry(&registry);
+
     emit(&ConsolidateScanComplete {
         event_type: "consolidate_scan_complete",
+        session_id,
         primary: cmd.primary.clone(),
         secondaries: secondary_results,
+    });
+}
+
+fn handle_build(cmd: BuildCmd) {
+    let target = PathBuf::from(&cmd.target);
+
+    // Create target directory if needed.
+    if let Err(e) = fs::create_dir_all(&target) {
+        emit_error(&format!("Failed to create target directory: {}", e));
+        return;
+    }
+
+    let mut files_copied = 0usize;
+    let mut secondary_records: Vec<SecondaryRecord> = Vec::new();
+
+    // Group fold_ins by source_root to build per-secondary records.
+    let mut by_source: std::collections::HashMap<String, (Vec<String>, Vec<String>)> =
+        std::collections::HashMap::new();
+
+    for fi in &cmd.fold_ins {
+        let entry = by_source.entry(fi.source_root.clone()).or_default();
+        entry.0.push(fi.relative_path.clone());
+        for s in &fi.skipped {
+            entry.1.push(s.clone());
+        }
+    }
+
+    for (source_root, (approved, skipped)) in &by_source {
+        let source_path = PathBuf::from(source_root);
+        let mut folded = 0usize;
+
+        for rel in approved {
+            let src = source_path.join(rel);
+            let dst = target.join(rel);
+
+            if let Some(parent) = dst.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            match fs::copy(&src, &dst) {
+                Ok(_) => {
+                    folded += 1;
+                    files_copied += 1;
+                }
+                Err(e) => {
+                    emit_error(&format!("Failed to copy {}: {}", rel, e));
+                }
+            }
+        }
+
+        let analyzed = now_iso();
+        secondary_records.push(SecondaryRecord {
+            path: source_root.clone(),
+            analyzed,
+            status: "complete".to_string(),
+            files_folded_in: folded,
+            files_skipped: skipped.len(),
+            skipped: skipped.clone(),
+        });
+    }
+
+    // Update registry — mark session complete with secondary records.
+    let mut registry = load_registry();
+    if let Some(session) = registry.sessions.iter_mut().find(|s| s.id == cmd.session_id) {
+        session.target = cmd.target.clone();
+        session.status = "complete".to_string();
+        session.secondaries = secondary_records;
+    }
+    save_registry(&registry);
+
+    emit(&ConsolidateBuildComplete {
+        event_type: "consolidate_build_complete",
+        session_id: cmd.session_id.clone(),
+        target: cmd.target.clone(),
+        files_copied,
+    });
+}
+
+fn handle_finalize(cmd: FinalizeCmd) {
+    let mut registry = load_registry();
+    if let Some(session) = registry.sessions.iter_mut().find(|s| s.id == cmd.session_id) {
+        session.status = "finalized".to_string();
+    }
+    save_registry(&registry);
+
+    emit(&ConsolidateFinalizeComplete {
+        event_type: "consolidate_finalize_complete",
+        session_id: cmd.session_id,
     });
 }
 
@@ -261,8 +557,10 @@ pub fn run_from_stdin() {
         emit_error("Failed to read command from stdin.");
         return;
     }
-    match serde_json::from_str::<ConsolidateScanCommand>(&input) {
-        Ok(cmd) => run(cmd),
+    match serde_json::from_str::<ConsolidateCommand>(&input) {
+        Ok(ConsolidateCommand::ConsolidateScan(cmd)) => handle_scan(cmd),
+        Ok(ConsolidateCommand::ConsolidateBuild(cmd)) => handle_build(cmd),
+        Ok(ConsolidateCommand::ConsolidateFinalize(cmd)) => handle_finalize(cmd),
         Err(e) => emit_error(&format!("Failed to parse consolidate command: {}", e)),
     }
 }

--- a/rust_core/tests/manifest_cli_test.rs
+++ b/rust_core/tests/manifest_cli_test.rs
@@ -417,3 +417,137 @@ fn consolidate_result_has_required_fields() {
         assert!(files[0]["size_bytes"].is_number(), "size_bytes missing");
     }
 }
+
+// ---------------------------------------------------------------------------
+// Registry tests (#96)
+// ---------------------------------------------------------------------------
+
+/// Run a consolidate_scan with an explicit session_id and an isolated registry.
+/// Returns (scan result Value, registry path).
+fn run_consolidate_with_session(
+    primary: &str,
+    secondaries: &[&str],
+    session_id: &str,
+    target: &str,
+    registry_path: &str,
+) -> Value {
+    let cmd = serde_json::json!({
+        "command": "consolidate_scan",
+        "primary": primary,
+        "secondaries": secondaries,
+        "session_id": session_id,
+        "target": target,
+    });
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rust_core"))
+        .arg("consolidate")
+        .env("FILESTEWARD_REGISTRY_PATH", registry_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("should spawn rust_core consolidate");
+
+    child.stdin.take().unwrap()
+        .write_all(cmd.to_string().as_bytes())
+        .unwrap();
+
+    let output = child.wait_with_output().expect("should complete");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if let Ok(v) = serde_json::from_str::<Value>(line) {
+            if v["type"] == "consolidate_scan_complete" {
+                return v;
+            }
+        }
+    }
+    panic!("no consolidate_scan_complete in output:\n{}", stdout);
+}
+
+fn run_consolidate_finalize(session_id: &str, registry_path: &str) -> Value {
+    let cmd = serde_json::json!({
+        "command": "consolidate_finalize",
+        "session_id": session_id,
+    });
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rust_core"))
+        .arg("consolidate")
+        .env("FILESTEWARD_REGISTRY_PATH", registry_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("should spawn rust_core consolidate");
+
+    child.stdin.take().unwrap()
+        .write_all(cmd.to_string().as_bytes())
+        .unwrap();
+
+    let output = child.wait_with_output().expect("should complete");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if let Ok(v) = serde_json::from_str::<Value>(line) {
+            if v["type"] == "consolidate_finalize_complete" {
+                return v;
+            }
+        }
+    }
+    panic!("no consolidate_finalize_complete in output:\n{}", stdout);
+}
+
+fn read_registry_at(path: &str) -> Value {
+    let content = std::fs::read_to_string(path)
+        .expect("sessions.json should exist after a scan");
+    serde_json::from_str(&content).expect("sessions.json should be valid JSON")
+}
+
+#[test]
+fn registry_scan_creates_session() {
+    let registry = std::env::temp_dir().join("fs_test_registry_scan_creates.json");
+    let registry_str = registry.to_str().unwrap();
+    let session_id = "test-registry-scan-creates";
+    let primary = consolidate_fixture("primary");
+    let sec_a = consolidate_fixture("secondary_a");
+
+    run_consolidate_with_session(
+        primary.to_str().unwrap(),
+        &[sec_a.to_str().unwrap()],
+        session_id,
+        "/tmp/test_consolidated",
+        registry_str,
+    );
+
+    let reg = read_registry_at(registry_str);
+    let sessions = reg["sessions"].as_array().expect("sessions array");
+    let session = sessions.iter().find(|s| s["id"] == session_id)
+        .expect("session should be in registry");
+
+    assert_eq!(session["status"], "in_progress");
+    assert_eq!(session["primary"], primary.to_str().unwrap());
+}
+
+#[test]
+fn registry_finalize_updates_status() {
+    let registry = std::env::temp_dir().join("fs_test_registry_finalize.json");
+    let registry_str = registry.to_str().unwrap();
+    let session_id = "test-registry-finalize";
+    let primary = consolidate_fixture("primary");
+    let sec_a = consolidate_fixture("secondary_a");
+
+    run_consolidate_with_session(
+        primary.to_str().unwrap(),
+        &[sec_a.to_str().unwrap()],
+        session_id,
+        "/tmp/test_consolidated_finalize",
+        registry_str,
+    );
+
+    let result = run_consolidate_finalize(session_id, registry_str);
+    assert_eq!(result["type"], "consolidate_finalize_complete");
+    assert_eq!(result["session_id"], session_id);
+
+    let reg = read_registry_at(registry_str);
+    let sessions = reg["sessions"].as_array().expect("sessions array");
+    let session = sessions.iter().find(|s| s["id"] == session_id)
+        .expect("session should be in registry");
+
+    assert_eq!(session["status"], "finalized");
+}


### PR DESCRIPTION
## Summary
- `~/.filesteward/sessions.json` registry: created on scan, updated on build (with per-secondary folded-in/skipped counts and skipped file paths), marked finalized on user action
- `FILESTEWARD_REGISTRY_PATH` env var overrides the registry path — used in tests to avoid parallel write races
- Supports three commands: `consolidate_scan`, `consolidate_build`, `consolidate_finalize`
- 2 new registry tests: session created with `in_progress` status on scan; status transitions to `finalized` after finalize command

## Closes
- #96 Rust: central session registry

## Test plan
- [ ] `cargo test --manifest-path rust_core/Cargo.toml` — all 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)