### PR TITLE
Iteration 8: two-panel tree view — Step 2 + Step 5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,9 +173,9 @@ Done:
 - Dart: _StepDot, _SectionHeader, _SourceTile, _BottomBar, _ErrorBanner,
   _ScopeChip, _SummaryChip → carry forward unchanged
 
-### Iteration 8 — Two-Panel Tree View (current — branch iter8-two-panel-tree, PR #123)
+### Iteration 8 — Two-Panel Tree View + Bulk Actions ✅ Complete (v0.7.0 — PR #123)
 
-**Shipped in this iteration (v0.6.2–0.6.7):**
+**Shipped in this iteration (v0.7.0):**
 - Step 2 lazy two-panel tree: source trees (left, color-coded) + merged target preview (right, source dots) — #118
 - Extension summary pill strip: horizontally scrollable, sorted by count, tap to exclude/include type
 - _kSystemExtensions constant: .ithmb, .ini, .db, .bz2, .gz, etc. pre-excluded by default
@@ -183,6 +183,9 @@ Done:
 - Scan respects excluded extensions (passes include list to Rust, not exclude list)
 - Rust hash_all_files_ext emits progress every 100 files — determinate scan progress bar
 - ScrollController moved to State (was recreated on every build — bug fix)
+- **Path truncation (feature):** two-line display format in Review step (bold filename, muted full path, no truncation)
+- **Bulk folder preference (feature):** right-click context menu with two operations (Prefer / Consolidate into)
+- **Designs locked for future implementation:** wrapper folder promotion, type-based routing
 
 **Known issues discovered during first real-data review session:**
 1. **Build hang on large datasets (#TBD)** — v2Build sends all file paths as one
@@ -294,10 +297,17 @@ Optional mode, toggled at Step 1. When enabled, files are routed into semantic t
 - Extension filter applies before routing (user excludes types at scan time)
 - Result: clean consolidated structure under canonical type folders
 
-**Deferred items (not Iteration 8):**
-- **`.photoslibrary` package skip** — skip during walking (internal DB files, not user content), emit warning. Deferred to pre-Maintain iteration.
-- **Consolidate-specific file type settings** — configurable list of standard types (`.ini`, `.dat`, `.db`, `.ffs_db`, etc.) that users can include/exclude per consolidation. Deferred to Consolidate configuration iteration.
-- **Maintain design** — all Maintain features deferred. Maintain operates on single live directories and has different filtering/type management needs than Consolidate.
+**Implemented features (Iteration 8):**
+- Path truncation design → implemented as two-line format
+- Bulk folder preference design → implemented with right-click menu and two operations
+
+**Deferred to Iteration 9+ (Consolidate UI Flow Redesign):**
+- **Wrapper folder promotion** — detection, merge proposal (Review), apply (Build)
+- **Type-based routing** — optional mode, file routing by extension + folder context, unknown extension gating
+- **New Review flow** — 6-step user journey: Scan → Review folder structures → Resolve ambiguous folders → Review ambiguous files → Final target review → Approve build
+- **`.photoslibrary` package skip** — safety measure for Rust walk phase
+- **Consolidate-specific file type settings** — configurable defaults per consolidation
+- **Maintain design** — entire Maintain product deferred until after Consolidate v2 complete
 
 **Folder exclusion note — design correction:**
 CLAUDE.md previously said "scan hashes everything; exclusions applied at build time."
@@ -362,12 +372,38 @@ the build command), so it is cleanly deferred here.
 - File-level override interactions (later pass)
 - Settings table for user-customisable important-extensions list
 
-### Iteration 9 — iPad/iPhone Review Client
+### Iteration 9 — Consolidate UI Flow Redesign: 6-Step User Journey
+
+**Goal:** Comprehensive redesign of the Review step to match user mental model. Replace current 3-step flow with 6-step flow that gives users visibility into folder structure cleanup and final output before build.
+
+**New flow (replaces current Review step):**
+1. **Scan** — count files, understand structure, types, exclude folders/types
+2. **Review folder structures** — see duplicate groups, suggest folder rationalization (wrapper promotion)
+3. **Resolve ambiguous folders** — clean up folder ambiguities
+4. **Review ambiguous files (Part A: Duplicates)** — resolution panel for duplicate groups
+5. **Review ambiguous files (Part B: Filenames)** — handle naming conflicts and ambiguities
+6. **Final target review** — interactive view of complete proposed output, all movements, verify structure
+7. **Approve build** — confirm and execute
+
+**Features to implement:**
+- Wrapper folder promotion: detect, propose merges, apply at Review #2
+- Type-based routing: route files to Pictures/Movies/Music/Documents based on content + folder context
+- Target structure preview: interactive tree showing what user will get after build
+- Unknown extension gating: force decisions on unrecognized file types before proceeding
+- Folder rationalization UI: surface suggestions about wrapper merges, naming issues
+
+**Reusable components:**
+- _TreeNode/_TreeNodeRow/_OriginalTreePanel from rationalize_screen (for target preview)
+- _DuplicateGroupsPanel from current Review (for duplicate resolution)
+- Bulk folder preference operations (Prefer / Consolidate into)
+- Path truncation UI (two-line format)
+
+### Iteration 10 — iPad/iPhone Review Client
 - Open saved scan, review groups, approve/reject recommendations
 - Focused scans via Apple document picker / security-scoped URLs
 - Sync saved scan state
 
-### Iteration 10 — Advanced UX + Performance
+### Iteration 11 — Advanced UX + Performance
 - Visual topology of folders and duplicate clusters
 - Performance tuning for large external drives (100k+ files)
 - Rules engine: user-defined naming and placement rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,16 +223,38 @@ Done:
    **Notes:**
    - Both operations include unique files from all sources in the final output
    - Right-click anywhere on a file path triggers the menu; folder name is extracted from the radio button group context
-4. **Wrapper folder promotion (#TBD)** — a pattern identified early in the project.
-   Some source folders contain a "wrapper" folder (e.g. My Pictures, My Documents,
-   My Pictures 2012) whose only purpose is to contain the real content one level down.
-   The consolidation preserves this wrapper as-is, producing parallel structures in
-   the target (e.g. top-level year folders from Source A alongside
-   My Pictures 2012/year folders from Source B) instead of merging them.
-   Fix: detect wrapper folder patterns and promote their contents one level,
-   merging with sibling folders of the same structure. Requires design —
-   detection heuristics, user confirmation, and how to handle naming conflicts.
-   This is related to but broader than OS name mapping (#122).
+4. **Wrapper folder promotion — LOCKED DESIGN.** Detect folders that are pure containers (wrappers) and promote their contents one level, merging parallel structures.
+
+   **Detection (Scan phase):**
+   - Known wrapper names: `My Pictures`, `My Documents`, `My Videos`, `My Music`, `My Photos`, `My Files`, + regional variants
+   - Structural heuristic: folders with 0 files at root OR >75% subdirectories + <5% files are flagged as potential wrappers
+   - All detected wrappers are flagged for review
+
+   **Merging criteria:**
+   - Two wrappers merge if:
+     - They share the same child folder names (e.g., both have `2000/`, `2001/`, `2003/`)
+     - AND they contain overlapping duplicate files in those children
+     - This signals they are backups of the same folder structure
+   
+   **Review-time surfacing:**
+   - Before duplicate group review, surface: "Wrapper folder merges detected"
+   - List each merge proposal: `"My Pictures" and "My Pictures 2012" share structure (2000/, 2001/, ...) — merge into Pictures?`
+   - User confirms or rejects each merge with checkbox
+   - Cannot proceed to duplicate review until all merge decisions are made
+   
+   **Build-time application:**
+   - For confirmed merges:
+     - Combine children from both wrappers (e.g., merge `My Pictures/2000/` with `My Pictures 2012/2000/`)
+     - Deduplicate files using existing duplicate logic
+     - Result: single output folder structure (e.g., `Pictures/2000/`, `Pictures/2001/`, ...)
+   - For wrappers NOT merged:
+     - If wrapper has year/event subfolders (e.g., `2000/`, `2001/`) → merge into canonical type folder (`Pictures/`)
+     - If wrapper has NO year subfolders (just files) → promote as subfolder under canonical folder (e.g., `My Pictures 2012/photo.jpg` → `Pictures/2012/photo.jpg`)
+   
+   **Interaction with type-based routing:**
+   - Wrapper merges apply first (structural cleanup)
+   - Type-based routing applies second (if enabled)
+   - Result: clean consolidated structure under canonical type folders (Pictures, Movies, Music, Documents)
 
 **Folder exclusion note — design correction:**
 CLAUDE.md previously said "scan hashes everything; exclusions applied at build time."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ Done:
 - Dart: _StepDot, _SectionHeader, _SourceTile, _BottomBar, _ErrorBanner,
   _ScopeChip, _SummaryChip → carry forward unchanged
 
-### Iteration 8 — Two-Panel Tree View (agreed 2026-04-03)
+### Iteration 8 — Two-Panel Tree View (current — PR #TBD)
 
 **Cut line from Iteration 7:** The two-panel layout materially changes the
 build step (Dart must translate folder-level include/exclude decisions into

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,34 @@ Done:
 - Dart: _StepDot, _SectionHeader, _SourceTile, _BottomBar, _ErrorBanner,
   _ScopeChip, _SummaryChip → carry forward unchanged
 
-### Iteration 8 — Two-Panel Tree View (current — PR #TBD)
+### Iteration 8 — Two-Panel Tree View (current — branch iter8-two-panel-tree, PR #123)
+
+**Shipped in this iteration (v0.6.2–0.6.7):**
+- Step 2 lazy two-panel tree: source trees (left, color-coded) + merged target preview (right, source dots) — #118
+- Extension summary pill strip: horizontally scrollable, sorted by count, tap to exclude/include type
+- _kSystemExtensions constant: .ithmb, .ini, .db, .bz2, .gz, etc. pre-excluded by default
+- Inventory loaded in background during Filter step; used for scan-total denominator
+- Scan respects excluded extensions (passes include list to Rust, not exclude list)
+- Rust hash_all_files_ext emits progress every 100 files — determinate scan progress bar
+- ScrollController moved to State (was recreated on every build — bug fix)
+
+**Known issues discovered during first real-data review session:**
+1. **Build hang on large datasets (#TBD)** — v2Build sends all file paths as one
+   JSON blob over stdin. With 30k+ files this blocks the UI thread writing to the pipe.
+   Fix: write build commands to a temp file; pass file path to Rust instead of stdin blob.
+   This is an architectural change requiring design before implementation.
+2. **Review step: path truncation (#TBD)** — duplicate group radio buttons show
+   truncated paths (…/folder/file.jpg) that are insufficient for decision-making.
+   Fix: show full paths, wrapping if needed.
+3. **Review step: bulk folder preference (#TBD)** — right-click a path option and
+   choose "Prefer this folder for all groups": sets keeper to that folder's copy for
+   every duplicate group that has a copy there. Unaffected groups unchanged.
+   Design needed before implementation.
+
+**Folder exclusion note — design correction:**
+CLAUDE.md previously said "scan hashes everything; exclusions applied at build time."
+This was wrong and has been corrected: excluded extensions are passed to Rust at scan
+time via include_extensions. Scan only hashes what will be used.
 
 **Cut line from Iteration 7:** The two-panel layout materially changes the
 build step (Dart must translate folder-level include/exclude decisions into
@@ -205,8 +232,8 @@ the build command), so it is cleanly deferred here.
 - Checkbox next to each folder node in the right panel; checked = included,
   unchecked = excluded — no toggles, no color-only states
 - Excluding a folder is absolute: nothing from it reaches the target
-- Step 2 exclusions affect the target only; the scan (Step 4) still hashes
-  everything — exclusions are applied when building, not when scanning
+- Step 2 exclusions are passed to Rust at scan time via include_extensions —
+  excluded types are not hashed at all (faster + accurate progress count)
 - Step 5 right panel uses the same checkbox model
 
 **Duplicate path indicator (Step 2 right panel):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,9 +189,11 @@ Done:
    JSON blob over stdin. With 30k+ files this blocks the UI thread writing to the pipe.
    Fix: write build commands to a temp file; pass file path to Rust instead of stdin blob.
    This is an architectural change requiring design before implementation.
-2. **Review step: path truncation (#TBD)** — duplicate group radio buttons show
-   truncated paths (…/folder/file.jpg) that are insufficient for decision-making.
-   Fix: show full paths, wrapping if needed.
+2. **Review step: path truncation — LOCKED DESIGN.** Display format: **filename** on line 1 (bold, primary), full folder path `/path/to/folder/` on line 2 (muted/secondary text, wraps if needed). No truncation. Filename is the focus; path provides full context. Example:
+   ```
+   **photo.jpg**
+   /Users/karlborn/My Pictures/2000/BikeSwim/
+   ```
 3. **Review step: bulk folder preference (#TBD)** — right-click a path option and
    choose "Prefer this folder for all groups": sets keeper to that folder's copy for
    every duplicate group that has a copy there. Unaffected groups unchanged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,10 +194,31 @@ Done:
    **photo.jpg**
    /Users/karlborn/My Pictures/2000/BikeSwim/
    ```
-3. **Review step: bulk folder preference (#TBD)** — right-click a path option and
-   choose "Prefer this folder for all groups": sets keeper to that folder's copy for
-   every duplicate group that has a copy there. Unaffected groups unchanged.
-   Design needed before implementation.
+3. **Review step: bulk folder preference — LOCKED DESIGN.** Right-click on any file path within a duplicate group to bulk-apply a keeper preference.
+
+   **Interaction:**
+   - User views a duplicate group with radio buttons for each folder's copy
+   - User right-clicks on a file path (e.g., "2000/BikeSwim/photo.jpg" under Folder A)
+   - Context menu appears with single option: `Prefer "Folder A" for all groups`
+   - User clicks it
+   - Action completes immediately (no confirmation dialog)
+   
+   **Effect:**
+   - For every duplicate group containing a copy from Folder A, set keeper = Folder A
+   - Groups without a Folder A copy remain unchanged (still ambiguous if they have >1 option)
+   - Visual feedback: Toast/snackbar appears: `"Set N groups to prefer Folder A"` with undo button
+   - Undo: reverts the bulk preference; affected groups return to "unresolved" state
+   - Duration: toast auto-dismisses in 4 seconds or when user dismisses
+   
+   **Reversibility:**
+   - User can undo via toast button within the toast lifetime
+   - After toast dismisses, user can override individual groups by clicking different radio buttons
+   - Build is still blocked until ALL groups (including those not affected by bulk preference) have keeper decisions
+   
+   **Edge cases:**
+   - If bulk preference resolves all remaining ambiguous groups → Build becomes available immediately
+   - If bulk preference leaves some groups unresolved → user continues reviewing those groups
+   - Right-click anywhere on a file path triggers the menu; the folder name for the menu item is extracted from the radio button group context
 4. **Wrapper folder promotion (#TBD)** — a pattern identified early in the project.
    Some source folders contain a "wrapper" folder (e.g. My Pictures, My Documents,
    My Pictures 2012) whose only purpose is to contain the real content one level down.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,48 @@ Done:
    - Type-based routing applies second (if enabled)
    - Result: clean consolidated structure under canonical type folders (Pictures, Movies, Music, Documents)
 
+## Type-based Consolidation Routing — LOCKED DESIGN
+
+Optional mode, toggled at Step 1. When enabled, files are routed into semantic type folders based on content and folder context.
+
+**Routing priority (context takes precedence over extension):**
+1. **Folder context (OS wrapper) wins:** If file is under an OS-mapped wrapper (`My Pictures` → `Pictures/`, `My Documents` → `Documents/`), the wrapper determines destination regardless of file extension.
+   - Example: `My Documents/Scans/photo.jpg` → `Documents/Scans/photo.jpg` (not `Pictures/`)
+2. **Extension-based routing (fallback):** If file has no OS wrapper context, extension determines destination:
+   - Image extensions (`.jpg`, `.heic`, `.png`, `.gif`, `.bmp`, `.raw`, etc.) → `Pictures/`
+   - Video extensions (`.mp4`, `.mov`, `.avi`, `.mkv`, etc.) → `Movies/`
+   - Audio extensions (`.mp3`, `.aac`, `.wav`, `.flac`, `.m4a`, etc.) → `Music/`
+   - Known document extensions (`.pdf`, `.docx`, `.xlsx`, `.pptx`, `.txt`, `.rtf`, etc.) → `Documents/`
+   - Unknown extensions → gated (see below)
+
+**Unknown extension handling:**
+- If an unknown extension has >10 files: filter step surfaces it as a group requiring a decision
+- User chooses per extension group: **Exclude** (don't copy), **Route to Documents**, or **Route to Other**
+- Build blocked until all unknown extension groups (>10 files) are resolved
+- `Other/` is intentional (user explicitly chose to defer), never silent
+
+**Path preservation:**
+- File path under the type folder preserves the containing folder structure
+- OS wrapper folder names are stripped (they collapse into the type folder root)
+- Example: `My Pictures/2000/BikeSwim/photo.jpg` → `Pictures/2000/BikeSwim/photo.jpg`
+
+**Mixed folders:**
+- File-level routing, not folder-level
+- A folder with both `.jpg` and `.xlsx` gets split: photos route to `Pictures/`, spreadsheets route to `Documents/`
+
+**Naming collision (unique files, different content, same output path):**
+- First: `photo.jpg`, Second: `photo2.jpg`, Third: `photo3.jpg`
+- Numeric suffix, no separator
+
+**Interaction with other features:**
+- Wrapper merges apply before type routing (structural cleanup first)
+- Extension filter applies before routing (user excludes types at scan time)
+- Result: clean consolidated structure under canonical type folders
+
+**Deferred items (not Iteration 8):**
+- **`.photoslibrary` package skip** — skip during walking (internal DB files, not user content), emit warning. Deferred to pre-Maintain iteration.
+- **Artifact extension management in settings** — configurable list of standard types (`.ini`, `.dat`, `.db`, `.ffs_db`, etc.) that users can include/exclude globally. This is a system-wide settings feature, not specific to Consolidate. Deferred to settings/configuration iteration.
+
 **Folder exclusion note — design correction:**
 CLAUDE.md previously said "scan hashes everything; exclusions applied at build time."
 This was wrong and has been corrected: excluded extensions are passed to Rust at scan

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,31 +194,35 @@ Done:
    **photo.jpg**
    /Users/karlborn/My Pictures/2000/BikeSwim/
    ```
-3. **Review step: bulk folder preference — LOCKED DESIGN.** Right-click on any file path within a duplicate group to bulk-apply a keeper preference.
+3. **Review step: bulk folder preference — LOCKED DESIGN.** Right-click on any file path within a duplicate group to bulk-apply a keeper preference. Two operations available.
 
    **Interaction:**
    - User views a duplicate group with radio buttons for each folder's copy
    - User right-clicks on a file path (e.g., "2000/BikeSwim/photo.jpg" under Folder A)
-   - Context menu appears with single option: `Prefer "Folder A" for all groups`
-   - User clicks it
-   - Action completes immediately (no confirmation dialog)
+   - Context menu appears with two options:
+     - `Prefer "Folder A" for all groups`
+     - `Consolidate into "Folder A"`
+   - User selects one; action completes immediately (no confirmation dialog)
    
-   **Effect:**
+   **Operation 1: Prefer [Folder] for all groups**
    - For every duplicate group containing a copy from Folder A, set keeper = Folder A
-   - Groups without a Folder A copy remain unchanged (still ambiguous if they have >1 option)
-   - Visual feedback: Toast/snackbar appears: `"Set N groups to prefer Folder A"` with undo button
-   - Undo: reverts the bulk preference; affected groups return to "unresolved" state
-   - Duration: toast auto-dismisses in 4 seconds or when user dismisses
+   - Groups without a Folder A copy remain unchanged (still need user resolution)
+   - Toast: `"Set N groups to prefer Folder A"` with undo button, 4-second auto-dismiss
+   - Build remains blocked until ALL groups resolved
    
-   **Reversibility:**
+   **Operation 2: Consolidate into [Folder]**
+   - For every duplicate group containing a copy from Folder A, set keeper = Folder A
+   - For duplicate groups NOT containing Folder A (B/C only): auto-resolve to first source (alphabetically)
+   - Toast: `"Consolidated N groups into Folder A"` with undo button, 4-second auto-dismiss
+   - If this resolves all ambiguous groups → Build becomes available immediately
+   
+   **Reversibility (both operations):**
    - User can undo via toast button within the toast lifetime
    - After toast dismisses, user can override individual groups by clicking different radio buttons
-   - Build is still blocked until ALL groups (including those not affected by bulk preference) have keeper decisions
    
-   **Edge cases:**
-   - If bulk preference resolves all remaining ambiguous groups → Build becomes available immediately
-   - If bulk preference leaves some groups unresolved → user continues reviewing those groups
-   - Right-click anywhere on a file path triggers the menu; the folder name for the menu item is extracted from the radio button group context
+   **Notes:**
+   - Both operations include unique files from all sources in the final output
+   - Right-click anywhere on a file path triggers the menu; folder name is extracted from the radio button group context
 4. **Wrapper folder promotion (#TBD)** — a pattern identified early in the project.
    Some source folders contain a "wrapper" folder (e.g. My Pictures, My Documents,
    My Pictures 2012) whose only purpose is to contain the real content one level down.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,8 @@ Optional mode, toggled at Step 1. When enabled, files are routed into semantic t
 
 **Deferred items (not Iteration 8):**
 - **`.photoslibrary` package skip** — skip during walking (internal DB files, not user content), emit warning. Deferred to pre-Maintain iteration.
-- **Artifact extension management in settings** — configurable list of standard types (`.ini`, `.dat`, `.db`, `.ffs_db`, etc.) that users can include/exclude globally. This is a system-wide settings feature, not specific to Consolidate. Deferred to settings/configuration iteration.
+- **Consolidate-specific file type settings** — configurable list of standard types (`.ini`, `.dat`, `.db`, `.ffs_db`, etc.) that users can include/exclude per consolidation. Deferred to Consolidate configuration iteration.
+- **Maintain design** — all Maintain features deferred. Maintain operates on single live directories and has different filtering/type management needs than Consolidate.
 
 **Folder exclusion note — design correction:**
 CLAUDE.md previously said "scan hashes everything; exclusions applied at build time."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,16 @@ Done:
    choose "Prefer this folder for all groups": sets keeper to that folder's copy for
    every duplicate group that has a copy there. Unaffected groups unchanged.
    Design needed before implementation.
+4. **Wrapper folder promotion (#TBD)** — a pattern identified early in the project.
+   Some source folders contain a "wrapper" folder (e.g. My Pictures, My Documents,
+   My Pictures 2012) whose only purpose is to contain the real content one level down.
+   The consolidation preserves this wrapper as-is, producing parallel structures in
+   the target (e.g. top-level year folders from Source A alongside
+   My Pictures 2012/year folders from Source B) instead of merging them.
+   Fix: detect wrapper folder patterns and promote their contents one level,
+   merging with sibling folders of the same structure. Requires design —
+   detection heuristics, user confirmation, and how to handle naming conflicts.
+   This is related to but broader than OS name mapping (#122).
 
 **Folder exclusion note — design correction:**
 CLAUDE.md previously said "scan hashes everything; exclusions applied at build time."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,14 @@
 - `main` is protected. No direct pushes.
 - All work happens on feature branches, merged via PR.
 - Branch naming: `iter3/short-description`, `design/topic`, `fix/topic`, `process/topic`.
+- Feature branches are **ephemeral** — delete after PR merge.
+- Worktrees are **ephemeral** — created per session, deleted when done. One iteration per thread.
+
+## Thread and iteration discipline
+
+- **One iteration per thread.** A thread is scoped to a single iteration. Never open a new thread mid-iteration.
+- **Handoffs only at iteration boundaries.** When an iteration is feature-complete, prepare a handoff for the next thread.
+- **Ephemeral branches and worktrees.** Feature branches are deleted after merge. Worktrees are created fresh for the session and removed when the iteration ships.
 
 ## Development workflow
 

--- a/lib/app_version.dart
+++ b/lib/app_version.dart
@@ -2,4 +2,4 @@
 ///
 /// Keep in sync with the `version` field in pubspec.yaml.
 /// Format: MAJOR.MINOR.PATCH (no build number).
-const String kAppVersion = '0.6.3';
+const String kAppVersion = '0.6.4';

--- a/lib/app_version.dart
+++ b/lib/app_version.dart
@@ -2,4 +2,4 @@
 ///
 /// Keep in sync with the `version` field in pubspec.yaml.
 /// Format: MAJOR.MINOR.PATCH (no build number).
-const String kAppVersion = '0.6.2';
+const String kAppVersion = '0.6.3';

--- a/lib/app_version.dart
+++ b/lib/app_version.dart
@@ -2,4 +2,4 @@
 ///
 /// Keep in sync with the `version` field in pubspec.yaml.
 /// Format: MAJOR.MINOR.PATCH (no build number).
-const String kAppVersion = '0.6.1';
+const String kAppVersion = '0.6.2';

--- a/lib/app_version.dart
+++ b/lib/app_version.dart
@@ -2,4 +2,4 @@
 ///
 /// Keep in sync with the `version` field in pubspec.yaml.
 /// Format: MAJOR.MINOR.PATCH (no build number).
-const String kAppVersion = '0.6.4';
+const String kAppVersion = '0.6.5';

--- a/lib/app_version.dart
+++ b/lib/app_version.dart
@@ -2,4 +2,4 @@
 ///
 /// Keep in sync with the `version` field in pubspec.yaml.
 /// Format: MAJOR.MINOR.PATCH (no build number).
-const String kAppVersion = '0.6.6';
+const String kAppVersion = '0.6.7';

--- a/lib/app_version.dart
+++ b/lib/app_version.dart
@@ -2,4 +2,4 @@
 ///
 /// Keep in sync with the `version` field in pubspec.yaml.
 /// Format: MAJOR.MINOR.PATCH (no build number).
-const String kAppVersion = '0.6.5';
+const String kAppVersion = '0.6.6';

--- a/lib/consolidate_screen.dart
+++ b/lib/consolidate_screen.dart
@@ -34,6 +34,27 @@ const _stepLabels = [
 ];
 
 // ---------------------------------------------------------------------------
+// System / junk extensions — pre-excluded by default in the Filter step.
+// These are OS metadata, thumbnails, cache, config, and archive types that
+// are almost never the target of a media/document consolidation.
+// ---------------------------------------------------------------------------
+
+const Set<String> _kSystemExtensions = {
+  // OS metadata & thumbnails
+  '.ithmb', '.ds_store', '.localized', '.spotlight-v100',
+  // Windows leftovers
+  '.ini', '.lnk', '.url', '.sys', '.dll',
+  // Databases & caches
+  '.db', '.sqlite', '.sqlite3', '.cache',
+  // Archives (typically not what you're consolidating)
+  '.bz2', '.gz', '.tar', '.zip', '.rar', '.7z', '.dmg', '.pkg',
+  // Logs & temp
+  '.log', '.tmp', '.temp',
+  // Package / build artefacts
+  '.plist', '.pkginfo', '.o', '.d',
+};
+
+// ---------------------------------------------------------------------------
 // Screen
 // ---------------------------------------------------------------------------
 
@@ -216,7 +237,22 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
         results[folder] = null;
       }
     }
-    if (mounted) setState(() => _inventories = results);
+    if (mounted) {
+      // Pre-exclude system/junk extensions that are present in these folders.
+      final systemPresent = <String>{};
+      for (final inv in results.values) {
+        if (inv == null) continue;
+        for (final stat in inv.extensions) {
+          if (_kSystemExtensions.contains(stat.extension.toLowerCase())) {
+            systemPresent.add(stat.extension);
+          }
+        }
+      }
+      setState(() {
+        _inventories = results;
+        _excludedExtensions.addAll(systemPresent);
+      });
+    }
   }
 
   // Step 1 → 2
@@ -662,12 +698,17 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
     final sorted = merged.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 
+    final stripController = ScrollController();
     return Container(
-      height: 36,
+      height: 44,
       color: Colors.grey[50],
-      child: ListView.separated(
+      child: Scrollbar(
+        controller: stripController,
+        thumbVisibility: true,
+        child: ListView.separated(
+        controller: stripController,
         scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        padding: const EdgeInsets.fromLTRB(12, 6, 12, 14),
         itemCount: sorted.length,
         separatorBuilder: (context, i) => const SizedBox(width: 6),
         itemBuilder: (context, i) {
@@ -721,6 +762,7 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
             ),
           );
         },
+        ),
       ),
     );
   }

--- a/lib/consolidate_screen.dart
+++ b/lib/consolidate_screen.dart
@@ -82,6 +82,7 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
   Map<String, InventoryResult?> _inventories = {};
   final Set<String> _excludedPaths = {};
   final Set<String> _excludedExtensions = {};
+  final _stripScrollController = ScrollController();
 
   // Step 3 — Scope (no async work here, just confirmation)
 
@@ -118,6 +119,7 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
   void dispose() {
     _elapsedTimer?.cancel();
     _targetNameController.dispose();
+    _stripScrollController.dispose();
     super.dispose();
   }
 
@@ -709,15 +711,14 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
     final sorted = merged.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 
-    final stripController = ScrollController();
     return Container(
       height: 44,
       color: Colors.grey[50],
       child: Scrollbar(
-        controller: stripController,
+        controller: _stripScrollController,
         thumbVisibility: true,
         child: ListView.separated(
-        controller: stripController,
+        controller: _stripScrollController,
         scrollDirection: Axis.horizontal,
         padding: const EdgeInsets.fromLTRB(12, 6, 12, 14),
         itemCount: sorted.length,

--- a/lib/consolidate_screen.dart
+++ b/lib/consolidate_screen.dart
@@ -6,8 +6,6 @@ import 'package:flutter/material.dart';
 
 import 'consolidate_models.dart';
 import 'consolidate_service.dart';
-import 'manifest_models.dart';
-import 'manifest_service.dart';
 
 // ---------------------------------------------------------------------------
 // Steps
@@ -34,26 +32,6 @@ const _stepLabels = [
 ];
 
 // ---------------------------------------------------------------------------
-// Important file extensions — pre-selected by default in the Filter step.
-// Empty _includeExtensions means "include everything"; this set seeds the
-// initial selection with the types most likely to matter for consolidation.
-// A future Settings screen will let users add to or modify this list.
-// ---------------------------------------------------------------------------
-
-const Set<String> _kImportantExtensions = {
-  // Photos
-  '.jpg', '.jpeg', '.png', '.heic', '.heif',
-  '.tiff', '.tif', '.raw', '.cr2', '.nef', '.bmp', '.gif', '.webp',
-  // Video
-  '.mp4', '.mov', '.avi', '.mkv', '.m4v', '.wmv', '.m2ts', '.3gp',
-  // Audio
-  '.mp3', '.m4a', '.aac', '.flac', '.wav', '.aiff', '.ogg',
-  // Documents
-  '.doc', '.docx', '.pdf', '.txt', '.rtf', '.odt', '.pages',
-  '.xls', '.xlsx', '.csv', '.numbers', '.ppt', '.pptx', '.key',
-};
-
-// ---------------------------------------------------------------------------
 // Screen
 // ---------------------------------------------------------------------------
 
@@ -66,7 +44,6 @@ class ConsolidateScreen extends StatefulWidget {
 
 class _ConsolidateScreenState extends State<ConsolidateScreen> {
   final _service = const ConsolidateService();
-  final _manifestService = const ManifestService();
 
   _Step _step = _Step.select;
 
@@ -76,10 +53,9 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
   final TextEditingController _targetNameController = TextEditingController();
   bool _targetManuallySet = false;
 
-  // Step 2 — Filter (inventory)
-  Map<String, InventoryResult?> _inventories = {};
-  bool _isLoadingInventories = false;
-  Set<String> _includeExtensions = {};
+  // Step 2 — Filter (tree view)
+  final Set<String> _excludedPaths = {};
+  final Set<String> _excludedExtensions = {};
 
   // Step 3 — Scope (no async work here, just confirmation)
 
@@ -214,46 +190,11 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
   // Step transitions
   // ---------------------------------------------------------------------------
 
-  // Step 0 → 1: load inventories for all selected folders
-  Future<void> _advanceToFilter() async {
-    setState(() {
-      _isLoadingInventories = true;
-      _step = _Step.filter;
-      _inventories = {};
-      _includeExtensions = {};
-      _errorMessage = null;
-    });
-
-    final results = <String, InventoryResult?>{};
-    for (final folder in _folders) {
-      try {
-        final inv = await _manifestService.buildInventory(folder);
-        results[folder] = inv;
-      } catch (_) {
-        results[folder] = null;
-      }
-    }
-
-    if (mounted) {
-      // Pre-select extensions that are both important AND present in these folders.
-      final present = <String>{};
-      for (final inv in results.values) {
-        if (inv == null) continue;
-        for (final stat in inv.extensions) {
-          present.add(stat.extension);
-        }
-      }
-      final preselected = present.intersection(_kImportantExtensions);
-
-      setState(() {
-        _inventories = results;
-        _isLoadingInventories = false;
-        // If any important types are present, pre-select them.
-        // If the folders contain only non-important types, default to all.
-        _includeExtensions = preselected.isNotEmpty ? preselected : {};
+  // Step 0 → 1: transition to tree filter view
+  void _advanceToFilter() => setState(() {
+        _step = _Step.filter;
+        _errorMessage = null;
       });
-    }
-  }
 
   // Step 1 → 2
   void _advanceToScope() => setState(() => _step = _Step.scope);
@@ -268,9 +209,8 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
     });
     _startTimer();
 
-    final extensions = _includeExtensions.isEmpty
-        ? <String>[]
-        : _includeExtensions.toList();
+    // Scan hashes everything; exclusions are applied at build time (#121).
+    const extensions = <String>[];
 
     ConsolidateUnifiedScanComplete? scanComplete;
 
@@ -651,144 +591,120 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
   }
 
   // ---------------------------------------------------------------------------
-  // Step 2 — Filter
+  // Step 2 — Filter (two-panel tree view)
   // ---------------------------------------------------------------------------
 
   Widget _buildFilterStep() {
-    if (_isLoadingInventories) {
-      return const Center(child: CircularProgressIndicator());
-    }
-
-    // Merge all extension stats across all folders.
-    final merged = <String, int>{};
-    for (final inv in _inventories.values) {
-      if (inv == null) continue;
-      for (final stat in inv.extensions) {
-        merged[stat.extension] =
-            (merged[stat.extension] ?? 0) + stat.count;
-      }
-    }
-    final sortedExts = merged.entries.toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
-
-    final maxCount =
-        sortedExts.isEmpty ? 1 : sortedExts.map((e) => e.value).reduce((a, b) => a > b ? a : b);
-
+    final excludedCount = _excludedPaths.length + _excludedExtensions.length;
     return Column(
       children: [
-        Expanded(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                _SectionHeader(
-                  title: 'Folder and File Filter',
-                  subtitle:
-                      'Common media and document types are pre-selected. Uncheck any you want to exclude, or check additional types.',
-                ),
-                const SizedBox(height: 12),
-                if (sortedExts.isEmpty)
-                  Text(
-                    'Could not load file type information.',
-                    style: TextStyle(color: Colors.grey[500]),
-                  )
-                else ...[
-                  // Select all / none
-                  Row(
+        // Panel headers row
+        IntrinsicHeight(
+          child: Row(
+            children: [
+              Expanded(
+                child: Container(
+                  color: Colors.grey[50],
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                  child: Row(
                     children: [
-                      SizedBox(
-                        width: 24,
-                        height: 24,
-                        child: Checkbox(
-                          tristate: true,
-                          value: _includeExtensions.isEmpty
-                              ? false
-                              : _includeExtensions.length == merged.length
-                                  ? true
-                                  : null,
-                          onChanged: (_) => setState(() {
-                            if (_includeExtensions.length == merged.length) {
-                              _includeExtensions = {};
-                            } else {
-                              _includeExtensions = merged.keys.toSet();
-                            }
-                          }),
-                          materialTapTargetSize:
-                              MaterialTapTargetSize.shrinkWrap,
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      const Text('All file types',
-                          style: TextStyle(
-                              fontWeight: FontWeight.w600, fontSize: 13)),
-                      const SizedBox(width: 8),
+                      const Icon(Icons.source, size: 15, color: Color(0xFF0E70C0)),
+                      const SizedBox(width: 6),
                       Text(
-                        _includeExtensions.isEmpty ? '(all included)' : '',
-                        style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+                        'Source Folders (${_folders.length})',
+                        style: const TextStyle(
+                            fontSize: 12, fontWeight: FontWeight.w600),
                       ),
                     ],
                   ),
-                  const Divider(height: 16),
-                  ...sortedExts.map((entry) {
-                    final isSelected =
-                        _includeExtensions.contains(entry.key);
-                    final label = entry.key.isEmpty
-                        ? '(no extension)'
-                        : entry.key;
-                    return Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 3),
-                      child: Row(
-                        children: [
-                          SizedBox(
-                            width: 24,
-                            height: 24,
-                            child: Checkbox(
-                              value: isSelected,
-                              onChanged: (checked) => setState(() {
-                                if (checked == true) {
-                                  _includeExtensions.add(entry.key);
-                                } else {
-                                  _includeExtensions.remove(entry.key);
-                                }
-                              }),
-                              materialTapTargetSize:
-                                  MaterialTapTargetSize.shrinkWrap,
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          SizedBox(
-                            width: 80,
-                            child: Text(
-                              label,
-                              style: const TextStyle(fontSize: 13),
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: LinearProgressIndicator(
-                              value: entry.value / maxCount,
-                              backgroundColor: Colors.grey[200],
-                              color: isSelected || _includeExtensions.isEmpty
-                                  ? const Color(0xFF0E70C0)
-                                  : Colors.grey[300],
-                              minHeight: 6,
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          Text(
-                            '${entry.value}',
-                            style: TextStyle(
-                                fontSize: 12, color: Colors.grey[600]),
-                          ),
-                        ],
+                ),
+              ),
+              const VerticalDivider(width: 1, thickness: 1),
+              Expanded(
+                child: Container(
+                  color: Colors.grey[50],
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.merge_type,
+                          size: 15, color: Color(0xFF0E70C0)),
+                      const SizedBox(width: 6),
+                      const Text(
+                        'Target Preview',
+                        style: TextStyle(
+                            fontSize: 12, fontWeight: FontWeight.w600),
                       ),
+                      if (excludedCount > 0) ...[
+                        const SizedBox(width: 8),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 6, vertical: 1),
+                          decoration: BoxDecoration(
+                            color: Colors.orange[100],
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: Text(
+                            '$excludedCount excluded',
+                            style: TextStyle(
+                                fontSize: 10, color: Colors.orange[800]),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        // Two-panel tree area
+        Expanded(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Left: source folder trees
+              Expanded(
+                child: ListView(
+                  padding: EdgeInsets.zero,
+                  children: _folders.asMap().entries.map((e) {
+                    return _SourceTreePanel(
+                      key: ValueKey('src_${e.key}_${e.value}'),
+                      folder: e.value,
+                      folderIndex: e.key,
+                      color: _folderColor(e.key),
+                      excludedPaths: _excludedPaths,
+                      excludedExtensions: _excludedExtensions,
+                      onExcludePath: (p) =>
+                          setState(() => _excludedPaths.add(p)),
+                      onIncludePath: (p) =>
+                          setState(() => _excludedPaths.remove(p)),
+                      onExcludeExt: (ext) =>
+                          setState(() => _excludedExtensions.add(ext)),
                     );
-                  }),
-                ],
-              ],
-            ),
+                  }).toList(),
+                ),
+              ),
+              const VerticalDivider(width: 1, thickness: 1),
+              // Right: merged target tree
+              Expanded(
+                child: _MergedTreePanel(
+                  key: ValueKey('merged_${_folders.join("|")}'),
+                  folders: _folders,
+                  colors: List.generate(_folders.length, _folderColor),
+                  excludedPaths: _excludedPaths,
+                  excludedExtensions: _excludedExtensions,
+                  onExcludePath: (p) =>
+                      setState(() => _excludedPaths.add(p)),
+                  onIncludePath: (p) =>
+                      setState(() => _excludedPaths.remove(p)),
+                  onExcludeExt: (ext) =>
+                      setState(() => _excludedExtensions.add(ext)),
+                ),
+              ),
+            ],
           ),
         ),
         _BottomBar(
@@ -811,22 +727,7 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
   // ---------------------------------------------------------------------------
 
   Widget _buildScopeStep() {
-    // Estimate total files from inventories.
-    int estimatedFiles = 0;
-    if (_includeExtensions.isEmpty) {
-      for (final inv in _inventories.values) {
-        if (inv != null) estimatedFiles += inv.totalFiles;
-      }
-    } else {
-      for (final inv in _inventories.values) {
-        if (inv == null) continue;
-        for (final stat in inv.extensions) {
-          if (_includeExtensions.contains(stat.extension)) {
-            estimatedFiles += stat.count;
-          }
-        }
-      }
-    }
+    final excludedCount = _excludedPaths.length + _excludedExtensions.length;
 
     return Column(
       children: [
@@ -883,17 +784,15 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
                         Row(
                           children: [
                             _ScopeChip(
-                              label: 'Files',
-                              value: estimatedFiles > 0
-                                  ? '~$estimatedFiles'
-                                  : '—',
+                              label: 'Scan',
+                              value: 'All files',
                             ),
                             const SizedBox(width: 16),
                             _ScopeChip(
-                              label: 'Types',
-                              value: _includeExtensions.isEmpty
-                                  ? 'All'
-                                  : '${_includeExtensions.length} selected',
+                              label: 'Excluded',
+                              value: excludedCount > 0
+                                  ? '$excludedCount items'
+                                  : 'None',
                             ),
                           ],
                         ),
@@ -1334,8 +1233,8 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
       _targetParentPath = null;
       _targetNameController.clear();
       _targetManuallySet = false;
-      _inventories = {};
-      _includeExtensions = {};
+      _excludedPaths.clear();
+      _excludedExtensions.clear();
       _scanResult = null;
       _sessionId = null;
       _filesCopied = 0;
@@ -1579,6 +1478,566 @@ class _SummaryChip extends StatelessWidget {
               style: const TextStyle(fontSize: 12),
               textAlign: TextAlign.center),
         ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tree data model
+// ---------------------------------------------------------------------------
+
+/// A node in a single-source directory tree (left panel).
+class _SourceNode {
+  final String name;
+  final String path; // absolute
+  final bool isDir;
+  List<_SourceNode>? children; // null = not yet loaded
+  bool isExpanded;
+
+  _SourceNode({required this.name, required this.path, required this.isDir})
+      : isExpanded = false;
+}
+
+/// A node in the merged target tree (right panel).
+class _MergedNode {
+  final String name;
+  final String relPath; // relative path from any source root
+  final bool isDir;
+  final Set<int> sourceIndices; // which source folders have this path
+  List<_MergedNode>? children; // null = not yet loaded
+  bool isExpanded;
+  bool isExcluded;
+
+  _MergedNode({
+    required this.name,
+    required this.relPath,
+    required this.isDir,
+    required this.sourceIndices,
+  })  : isExpanded = false,
+        isExcluded = false;
+}
+
+/// Actions available on a tree node context menu.
+enum _TreeAction { excludeFile, excludeExt, excludeFolder, include }
+
+// ---------------------------------------------------------------------------
+// Lazy directory loader helpers
+// ---------------------------------------------------------------------------
+
+List<_SourceNode> _loadSourceChildren(String dirPath) {
+  final dir = Directory(dirPath);
+  if (!dir.existsSync()) return [];
+  try {
+    final entities = dir.listSync(recursive: false, followLinks: false)
+      ..sort((a, b) {
+        final aDir = a is Directory;
+        final bDir = b is Directory;
+        if (aDir != bDir) return aDir ? -1 : 1;
+        return a.path.split('/').last
+            .toLowerCase()
+            .compareTo(b.path.split('/').last.toLowerCase());
+      });
+    return entities
+        .where((e) => !e.path.split('/').last.startsWith('.'))
+        .map((e) => _SourceNode(
+              name: e.path.split('/').last,
+              path: e.path,
+              isDir: e is Directory,
+            ))
+        .toList();
+  } catch (_) {
+    return [];
+  }
+}
+
+List<_MergedNode> _buildMergedChildren(
+    String relPath, List<String> sourceFolders) {
+  // Collect all child names across source folders at this relative path.
+  final nameToSources = <String, Set<int>>{};
+  final nameIsDir = <String, bool>{};
+
+  for (int i = 0; i < sourceFolders.length; i++) {
+    final dirPath = relPath.isEmpty
+        ? sourceFolders[i]
+        : '${sourceFolders[i]}/$relPath';
+    final dir = Directory(dirPath);
+    if (!dir.existsSync()) continue;
+    try {
+      for (final entity
+          in dir.listSync(recursive: false, followLinks: false)) {
+        final name = entity.path.split('/').last;
+        if (name.startsWith('.')) continue;
+        nameToSources.putIfAbsent(name, () => {}).add(i);
+        // isDir wins if any source says it's a dir.
+        nameIsDir[name] = (nameIsDir[name] ?? false) || entity is Directory;
+      }
+    } catch (_) {}
+  }
+
+  final entries = nameToSources.entries.toList()
+    ..sort((a, b) {
+      final aDir = nameIsDir[a.key] ?? false;
+      final bDir = nameIsDir[b.key] ?? false;
+      if (aDir != bDir) return aDir ? -1 : 1;
+      return a.key.toLowerCase().compareTo(b.key.toLowerCase());
+    });
+
+  return entries.map((e) {
+    final childRel = relPath.isEmpty ? e.key : '$relPath/${e.key}';
+    return _MergedNode(
+      name: e.key,
+      relPath: childRel,
+      isDir: nameIsDir[e.key] ?? false,
+      sourceIndices: e.value,
+    );
+  }).toList();
+}
+
+// ---------------------------------------------------------------------------
+// _SourceTreePanel — one source folder tree (left panel)
+// ---------------------------------------------------------------------------
+
+class _SourceTreePanel extends StatefulWidget {
+  final String folder;
+  final int folderIndex;
+  final Color color;
+  final Set<String> excludedPaths;
+  final Set<String> excludedExtensions;
+  final void Function(String) onExcludePath;
+  final void Function(String) onIncludePath;
+  final void Function(String) onExcludeExt;
+
+  const _SourceTreePanel({
+    super.key,
+    required this.folder,
+    required this.folderIndex,
+    required this.color,
+    required this.excludedPaths,
+    required this.excludedExtensions,
+    required this.onExcludePath,
+    required this.onIncludePath,
+    required this.onExcludeExt,
+  });
+
+  @override
+  State<_SourceTreePanel> createState() => _SourceTreePanelState();
+}
+
+class _SourceTreePanelState extends State<_SourceTreePanel> {
+  late _SourceNode _root;
+
+  @override
+  void initState() {
+    super.initState();
+    _root = _SourceNode(
+        name: widget.folder.split('/').last,
+        path: widget.folder,
+        isDir: true);
+    _root.isExpanded = true;
+    _root.children = _loadSourceChildren(widget.folder);
+  }
+
+  void _toggle(_SourceNode node) {
+    setState(() {
+      if (!node.isExpanded) {
+        node.children ??= _loadSourceChildren(node.path);
+      }
+      node.isExpanded = !node.isExpanded;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Folder header
+        Container(
+          padding:
+              const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: widget.color.withValues(alpha: 0.06),
+            border: Border(
+                bottom: BorderSide(
+                    color: widget.color.withValues(alpha: 0.3))),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 8,
+                height: 8,
+                margin: const EdgeInsets.only(right: 7),
+                decoration: BoxDecoration(
+                    color: widget.color, shape: BoxShape.circle),
+              ),
+              Text(
+                'Folder ${widget.folderIndex + 1}',
+                style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: widget.color),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  widget.folder,
+                  style:
+                      TextStyle(fontSize: 11, color: Colors.grey[600]),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+        // Tree nodes
+        ..._buildNodeList(_root.children ?? [], depth: 0),
+      ],
+    );
+  }
+
+  List<Widget> _buildNodeList(List<_SourceNode> nodes, {required int depth}) {
+    final widgets = <Widget>[];
+    for (final node in nodes) {
+      final ext = node.isDir
+          ? ''
+          : node.name.contains('.')
+              ? '.${node.name.split('.').last.toLowerCase()}'
+              : '';
+      final isExcluded = widget.excludedPaths.contains(node.path) ||
+          (!node.isDir && widget.excludedExtensions.contains(ext));
+
+      widgets.add(_TreeNodeRow(
+        name: node.name,
+        isDir: node.isDir,
+        isExpanded: node.isExpanded,
+        isExcluded: isExcluded,
+        depth: depth,
+        accentColor: widget.color,
+        onTap: node.isDir ? () => _toggle(node) : null,
+        contextItems: _contextItems(node, isExcluded, ext),
+        onContextAction: (action) => _handleAction(action, node, ext),
+      ));
+
+      if (node.isDir && node.isExpanded && node.children != null) {
+        widgets.addAll(_buildNodeList(node.children!, depth: depth + 1));
+      }
+    }
+    return widgets;
+  }
+
+  List<PopupMenuEntry<_TreeAction>> _contextItems(
+      _SourceNode node, bool isExcluded, String ext) {
+    if (isExcluded) {
+      return [
+        const PopupMenuItem(
+            value: _TreeAction.include,
+            child: Text('Include again')),
+      ];
+    }
+    if (node.isDir) {
+      return [
+        const PopupMenuItem(
+            value: _TreeAction.excludeFolder,
+            child: Text('Exclude this folder')),
+      ];
+    }
+    return [
+      const PopupMenuItem(
+          value: _TreeAction.excludeFile,
+          child: Text('Exclude this file')),
+      if (ext.isNotEmpty)
+        PopupMenuItem(
+            value: _TreeAction.excludeExt,
+            child: Text('Exclude all $ext files')),
+    ];
+  }
+
+  void _handleAction(_TreeAction action, _SourceNode node, String ext) {
+    switch (action) {
+      case _TreeAction.excludeFile:
+      case _TreeAction.excludeFolder:
+        widget.onExcludePath(node.path);
+      case _TreeAction.excludeExt:
+        widget.onExcludeExt(ext);
+      case _TreeAction.include:
+        widget.onIncludePath(node.path);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// _MergedTreePanel — naive merged target tree (right panel)
+// ---------------------------------------------------------------------------
+
+class _MergedTreePanel extends StatefulWidget {
+  final List<String> folders;
+  final List<Color> colors;
+  final Set<String> excludedPaths;
+  final Set<String> excludedExtensions;
+  final void Function(String) onExcludePath;
+  final void Function(String) onIncludePath;
+  final void Function(String) onExcludeExt;
+
+  const _MergedTreePanel({
+    super.key,
+    required this.folders,
+    required this.colors,
+    required this.excludedPaths,
+    required this.excludedExtensions,
+    required this.onExcludePath,
+    required this.onIncludePath,
+    required this.onExcludeExt,
+  });
+
+  @override
+  State<_MergedTreePanel> createState() => _MergedTreePanelState();
+}
+
+class _MergedTreePanelState extends State<_MergedTreePanel> {
+  List<_MergedNode> _roots = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _roots = _buildMergedChildren('', widget.folders);
+  }
+
+  void _toggle(_MergedNode node) {
+    setState(() {
+      if (!node.isExpanded) {
+        node.children ??=
+            _buildMergedChildren(node.relPath, widget.folders);
+      }
+      node.isExpanded = !node.isExpanded;
+    });
+  }
+
+  bool _isExcluded(_MergedNode node) {
+    final ext = node.isDir
+        ? ''
+        : node.name.contains('.')
+            ? '.${node.name.split('.').last.toLowerCase()}'
+            : '';
+    // Check if all source-absolute paths are excluded.
+    final allSourcePaths = node.sourceIndices.map(
+        (i) => '${widget.folders[i]}/${node.relPath}');
+    if (allSourcePaths.every((p) => widget.excludedPaths.contains(p))) {
+      return true;
+    }
+    if (!node.isDir && widget.excludedExtensions.contains(ext)) return true;
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_roots.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text('No files to preview.',
+              style: TextStyle(color: Colors.grey)),
+        ),
+      );
+    }
+    return ListView(
+      padding: EdgeInsets.zero,
+      children: _buildNodeList(_roots, depth: 0),
+    );
+  }
+
+  List<Widget> _buildNodeList(List<_MergedNode> nodes,
+      {required int depth}) {
+    final widgets = <Widget>[];
+    for (final node in nodes) {
+      final excluded = _isExcluded(node);
+      final ext = node.isDir
+          ? ''
+          : node.name.contains('.')
+              ? '.${node.name.split('.').last.toLowerCase()}'
+              : '';
+
+      // Source dots — one per contributing source folder.
+      final dots = node.sourceIndices
+          .where((i) => i < widget.colors.length)
+          .map((i) => widget.colors[i])
+          .toList();
+
+      widgets.add(_TreeNodeRow(
+        name: node.name,
+        isDir: node.isDir,
+        isExpanded: node.isExpanded,
+        isExcluded: excluded,
+        depth: depth,
+        accentColor: Colors.grey[700]!,
+        sourceDots: dots,
+        onTap: node.isDir ? () => _toggle(node) : null,
+        contextItems: _contextItems(node, excluded, ext),
+        onContextAction: (action) => _handleAction(action, node, ext),
+      ));
+
+      if (node.isDir && node.isExpanded && node.children != null) {
+        widgets.addAll(_buildNodeList(node.children!, depth: depth + 1));
+      }
+    }
+    return widgets;
+  }
+
+  List<PopupMenuEntry<_TreeAction>> _contextItems(
+      _MergedNode node, bool excluded, String ext) {
+    if (excluded) {
+      return [
+        const PopupMenuItem(
+            value: _TreeAction.include,
+            child: Text('Include again')),
+      ];
+    }
+    if (node.isDir) {
+      return [
+        const PopupMenuItem(
+            value: _TreeAction.excludeFolder,
+            child: Text('Exclude this folder')),
+      ];
+    }
+    return [
+      const PopupMenuItem(
+          value: _TreeAction.excludeFile,
+          child: Text('Exclude this file')),
+      if (ext.isNotEmpty)
+        PopupMenuItem(
+            value: _TreeAction.excludeExt,
+            child: Text('Exclude all $ext files')),
+    ];
+  }
+
+  void _handleAction(_TreeAction action, _MergedNode node, String ext) {
+    switch (action) {
+      case _TreeAction.excludeFile:
+        // Exclude path in every source that has it.
+        for (final i in node.sourceIndices) {
+          widget.onExcludePath('${widget.folders[i]}/${node.relPath}');
+        }
+      case _TreeAction.excludeFolder:
+        for (final i in node.sourceIndices) {
+          widget.onExcludePath('${widget.folders[i]}/${node.relPath}');
+        }
+      case _TreeAction.excludeExt:
+        widget.onExcludeExt(ext);
+      case _TreeAction.include:
+        for (final i in node.sourceIndices) {
+          widget.onIncludePath('${widget.folders[i]}/${node.relPath}');
+        }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// _TreeNodeRow — one row in a tree panel
+// ---------------------------------------------------------------------------
+
+class _TreeNodeRow extends StatelessWidget {
+  final String name;
+  final bool isDir;
+  final bool isExpanded;
+  final bool isExcluded;
+  final int depth;
+  final Color accentColor;
+  final List<Color>? sourceDots;
+  final VoidCallback? onTap;
+  final List<PopupMenuEntry<_TreeAction>> contextItems;
+  final void Function(_TreeAction) onContextAction;
+
+  const _TreeNodeRow({
+    required this.name,
+    required this.isDir,
+    required this.isExpanded,
+    required this.isExcluded,
+    required this.depth,
+    required this.accentColor,
+    required this.contextItems,
+    required this.onContextAction,
+    this.sourceDots,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final indent = 8.0 + depth * 14.0;
+    final textStyle = TextStyle(
+      fontSize: 12,
+      color: isExcluded ? Colors.grey[400] : null,
+      decoration: isExcluded ? TextDecoration.lineThrough : null,
+    );
+
+    return GestureDetector(
+      onSecondaryTapUp: contextItems.isEmpty
+          ? null
+          : (details) async {
+              final action = await showMenu<_TreeAction>(
+                context: context,
+                position: RelativeRect.fromLTRB(
+                  details.globalPosition.dx,
+                  details.globalPosition.dy,
+                  details.globalPosition.dx + 1,
+                  details.globalPosition.dy + 1,
+                ),
+                items: contextItems,
+              );
+              if (action != null) onContextAction(action);
+            },
+      child: InkWell(
+        onTap: onTap,
+        child: SizedBox(
+          height: 22,
+          child: Row(
+            children: [
+              SizedBox(width: indent),
+              // Chevron / spacer
+              if (isDir)
+                Icon(
+                  isExpanded ? Icons.expand_more : Icons.chevron_right,
+                  size: 14,
+                  color: Colors.grey[500],
+                )
+              else
+                const SizedBox(width: 14),
+              const SizedBox(width: 2),
+              // File/folder icon
+              Icon(
+                isDir ? Icons.folder : Icons.insert_drive_file,
+                size: 13,
+                color: isExcluded
+                    ? Colors.grey[300]
+                    : isDir
+                        ? Colors.amber[700]
+                        : Colors.grey[500],
+              ),
+              const SizedBox(width: 4),
+              // Name
+              Expanded(
+                child: Text(name, style: textStyle,
+                    overflow: TextOverflow.ellipsis),
+              ),
+              // Source dots (merged panel only)
+              if (sourceDots != null && sourceDots!.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: sourceDots!
+                        .map((c) => Container(
+                              width: 6,
+                              height: 6,
+                              margin: const EdgeInsets.only(left: 3),
+                              decoration: BoxDecoration(
+                                  color: c, shape: BoxShape.circle),
+                            ))
+                        .toList(),
+                  ),
+                ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/consolidate_screen.dart
+++ b/lib/consolidate_screen.dart
@@ -1286,21 +1286,30 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
+                        // Filename (bold, line 1)
                         Text(
-                          _shortPath(absPath),
+                          _leafName(absPath),
                           style: TextStyle(
                             fontSize: 12,
-                            fontWeight: isChosen
-                                ? FontWeight.w600
-                                : FontWeight.normal,
+                            fontWeight: FontWeight.w600,
                           ),
-                          overflow: TextOverflow.ellipsis,
+                        ),
+                        // Full path (muted, line 2)
+                        Text(
+                          absPath,
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: Colors.grey[600],
+                          ),
                         ),
                         if (group.reasons.isNotEmpty && isChosen)
-                          Text(
-                            group.reasons.join(', '),
-                            style: TextStyle(
-                                fontSize: 11, color: Colors.grey[500]),
+                          Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Text(
+                              group.reasons.join(', '),
+                              style: TextStyle(
+                                  fontSize: 10, color: Colors.grey[500]),
+                            ),
                           ),
                       ],
                     ),

--- a/lib/consolidate_screen.dart
+++ b/lib/consolidate_screen.dart
@@ -61,6 +61,7 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
 
   // Step 4 — Scan
   int _scanFilesCount = 0;
+  int _scanTotal = 0; // pre-counted before hashing starts
   String _scanningSource = '';
   DateTime? _scanStartTime;
   Duration _elapsed = Duration.zero;
@@ -186,6 +187,24 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
     _elapsedTimer = null;
   }
 
+  // Fast recursive file count — no hashing, just walk the tree.
+  // Used to get a denominator for the determinate scan progress bar.
+  Future<int> _countFiles(List<String> folders) async {
+    int total = 0;
+    for (final folder in folders) {
+      try {
+        await for (final entity in Directory(folder)
+            .list(recursive: true, followLinks: false)) {
+          if (entity is File &&
+              !entity.path.split('/').last.startsWith('.')) {
+            total++;
+          }
+        }
+      } catch (_) {}
+    }
+    return total;
+  }
+
   // ---------------------------------------------------------------------------
   // Step transitions
   // ---------------------------------------------------------------------------
@@ -204,10 +223,15 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
     setState(() {
       _step = _Step.scan;
       _scanFilesCount = 0;
+      _scanTotal = 0;
       _scanningSource = '';
       _errorMessage = null;
     });
     _startTimer();
+
+    // Quick pre-count (no hashing) to get a denominator for the progress bar.
+    final total = await _countFiles(_folders);
+    if (mounted) setState(() => _scanTotal = total);
 
     // Scan hashes everything; exclusions are applied at build time (#121).
     const extensions = <String>[];
@@ -865,13 +889,20 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
                 overflow: TextOverflow.ellipsis,
               ),
             const SizedBox(height: 16),
-            const LinearProgressIndicator(),
+            LinearProgressIndicator(
+              value: (_scanTotal > 0 && _scanFilesCount > 0)
+                  ? (_scanFilesCount / _scanTotal).clamp(0.0, 1.0)
+                  : null, // indeterminate until we have both counts
+            ),
             const SizedBox(height: 8),
-            if (_scanFilesCount > 0)
-              Text(
-                '$_scanFilesCount files hashed',
-                style: TextStyle(fontSize: 12, color: Colors.grey[500]),
-              ),
+            Text(
+              _scanTotal > 0
+                  ? '$_scanFilesCount / $_scanTotal files hashed'
+                  : _scanFilesCount > 0
+                      ? '$_scanFilesCount files hashed'
+                      : 'Counting files…',
+              style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+            ),
           ],
         ),
       ),
@@ -1235,6 +1266,7 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
       _targetManuallySet = false;
       _excludedPaths.clear();
       _excludedExtensions.clear();
+      _scanTotal = 0;
       _scanResult = null;
       _sessionId = null;
       _filesCopied = 0;

--- a/lib/consolidate_screen.dart
+++ b/lib/consolidate_screen.dart
@@ -1283,35 +1283,39 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
                   ),
                   const SizedBox(width: 8),
                   Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        // Filename (bold, line 1)
-                        Text(
-                          _leafName(absPath),
-                          style: TextStyle(
-                            fontSize: 12,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                        // Full path (muted, line 2)
-                        Text(
-                          absPath,
-                          style: TextStyle(
-                            fontSize: 11,
-                            color: Colors.grey[600],
-                          ),
-                        ),
-                        if (group.reasons.isNotEmpty && isChosen)
-                          Padding(
-                            padding: const EdgeInsets.only(top: 4),
-                            child: Text(
-                              group.reasons.join(', '),
-                              style: TextStyle(
-                                  fontSize: 10, color: Colors.grey[500]),
+                    child: GestureDetector(
+                      onSecondaryTapUp: (details) =>
+                          _showBulkPreferenceMenu(context, groupIdx, absPath, details.globalPosition),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          // Filename (bold, line 1)
+                          Text(
+                            _leafName(absPath),
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
                             ),
                           ),
-                      ],
+                          // Full path (muted, line 2)
+                          Text(
+                            absPath,
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: Colors.grey[600],
+                            ),
+                          ),
+                          if (group.reasons.isNotEmpty && isChosen)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 4),
+                              child: Text(
+                                group.reasons.join(', '),
+                                style: TextStyle(
+                                    fontSize: 10, color: Colors.grey[500]),
+                              ),
+                            ),
+                        ],
+                      ),
                     ),
                   ),
                 ],
@@ -1319,6 +1323,130 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
             ),
           );
         }).toList(),
+      ),
+    );
+  }
+
+  /// Show context menu for bulk folder preference operations.
+  void _showBulkPreferenceMenu(
+      BuildContext context, int groupIdx, String absPath, Offset position) {
+    // Extract folder name from absolute path
+    final folderName = _extractFolderName(absPath);
+    if (folderName == null) return;
+
+    showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        position.dx,
+        position.dy,
+      ),
+      items: [
+        PopupMenuItem<String>(
+          value: 'prefer',
+          child: Text('Prefer "$folderName" for all groups'),
+          onTap: () => _applyPreferFolderAll(groupIdx, absPath, folderName),
+        ),
+        PopupMenuItem<String>(
+          value: 'consolidate',
+          child: Text('Consolidate into "$folderName"'),
+          onTap: () =>
+              _applyConsolidateIntoFolder(groupIdx, absPath, folderName),
+        ),
+      ],
+    );
+  }
+
+  /// Extract folder name from absolute path (first path component).
+  String? _extractFolderName(String absPath) {
+    final parts = absPath.split('/').where((p) => p.isNotEmpty).toList();
+    return parts.isNotEmpty ? parts.first : null;
+  }
+
+  /// Apply "Prefer [Folder] for all groups" operation.
+  void _applyPreferFolderAll(int groupIdx, String absPath, String folderName) {
+    final result = _scanResult;
+    if (result == null) return;
+
+    int affectedCount = 0;
+    for (int i = 0; i < result.duplicateGroups.length; i++) {
+      final group = result.duplicateGroups[i];
+      // Check if this group has a file from the same folder
+      if (group.paths.any((p) => p.startsWith(absPath.split('/').first))) {
+        // Find the keeper from this folder
+        final folderPath = group.paths
+            .firstWhere((p) => p.startsWith(absPath.split('/').first), orElse: () => '');
+        if (folderPath.isNotEmpty) {
+          _keeperDecisions[i] = folderPath;
+          affectedCount++;
+        }
+      }
+    }
+
+    if (affectedCount > 0) {
+      _showUndoableToast(
+        'Set $affectedCount groups to prefer "$folderName"',
+        () {
+          // Undo: revert the decisions
+          for (int i = 0; i < result.duplicateGroups.length; i++) {
+            _keeperDecisions.remove(i);
+          }
+          setState(() {});
+        },
+      );
+      setState(() {});
+    }
+  }
+
+  /// Apply "Consolidate into [Folder]" operation.
+  void _applyConsolidateIntoFolder(
+      int groupIdx, String absPath, String folderName) {
+    final result = _scanResult;
+    if (result == null) return;
+
+    int affectedCount = 0;
+    for (int i = 0; i < result.duplicateGroups.length; i++) {
+      final group = result.duplicateGroups[i];
+      final folderPrefix = absPath.split('/').first;
+
+      if (group.paths.any((p) => p.startsWith(folderPrefix))) {
+        // Set keeper from this folder if available
+        final folderPath = group.paths.firstWhere(
+          (p) => p.startsWith(folderPrefix),
+          orElse: () => group.paths.first, // Fallback to first
+        );
+        _keeperDecisions[i] = folderPath;
+        affectedCount++;
+      }
+    }
+
+    if (affectedCount > 0) {
+      _showUndoableToast(
+        'Consolidated $affectedCount groups into "$folderName"',
+        () {
+          // Undo: revert the decisions
+          for (int i = 0; i < result.duplicateGroups.length; i++) {
+            _keeperDecisions.remove(i);
+          }
+          setState(() {});
+        },
+      );
+      setState(() {});
+    }
+  }
+
+  /// Show a toast with an undo button.
+  void _showUndoableToast(String message, VoidCallback onUndo) {
+    final scaffold = ScaffoldMessenger.of(context);
+    scaffold.showSnackBar(
+      SnackBar(
+        content: Text(message),
+        duration: const Duration(seconds: 4),
+        action: SnackBarAction(
+          label: 'Undo',
+          onPressed: onUndo,
+        ),
       ),
     );
   }

--- a/lib/consolidate_screen.dart
+++ b/lib/consolidate_screen.dart
@@ -284,8 +284,19 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
     }
     if (mounted) setState(() => _scanTotal = total);
 
-    // Scan hashes everything; exclusions are applied at build time (#121).
-    const extensions = <String>[];
+    // Compute effective include list: all present extensions minus excluded ones.
+    // Passing an empty list means "include everything" to Rust, so we only pass
+    // an explicit list when there are exclusions to apply.
+    final allExtensions = <String>{};
+    for (final inv in _inventories.values) {
+      if (inv == null) continue;
+      for (final stat in inv.extensions) {
+        allExtensions.add(stat.extension);
+      }
+    }
+    final extensions = _excludedExtensions.isEmpty
+        ? <String>[]
+        : allExtensions.difference(_excludedExtensions).toList();
 
     ConsolidateUnifiedScanComplete? scanComplete;
 

--- a/lib/consolidate_screen.dart
+++ b/lib/consolidate_screen.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 
 import 'consolidate_models.dart';
 import 'consolidate_service.dart';
+import 'manifest_models.dart';
+import 'manifest_service.dart';
 
 // ---------------------------------------------------------------------------
 // Steps
@@ -44,6 +46,7 @@ class ConsolidateScreen extends StatefulWidget {
 
 class _ConsolidateScreenState extends State<ConsolidateScreen> {
   final _service = const ConsolidateService();
+  final _manifestService = const ManifestService();
 
   _Step _step = _Step.select;
 
@@ -54,6 +57,8 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
   bool _targetManuallySet = false;
 
   // Step 2 — Filter (tree view)
+  // Inventories loaded during _advanceToFilter() — used for scan total estimate.
+  Map<String, InventoryResult?> _inventories = {};
   final Set<String> _excludedPaths = {};
   final Set<String> _excludedExtensions = {};
 
@@ -187,33 +192,32 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
     _elapsedTimer = null;
   }
 
-  // Fast recursive file count — no hashing, just walk the tree.
-  // Used to get a denominator for the determinate scan progress bar.
-  Future<int> _countFiles(List<String> folders) async {
-    int total = 0;
-    for (final folder in folders) {
-      try {
-        await for (final entity in Directory(folder)
-            .list(recursive: true, followLinks: false)) {
-          if (entity is File &&
-              !entity.path.split('/').last.startsWith('.')) {
-            total++;
-          }
-        }
-      } catch (_) {}
-    }
-    return total;
-  }
-
   // ---------------------------------------------------------------------------
   // Step transitions
   // ---------------------------------------------------------------------------
 
-  // Step 0 → 1: transition to tree filter view
-  void _advanceToFilter() => setState(() {
-        _step = _Step.filter;
-        _errorMessage = null;
-      });
+  // Step 0 → 1: show tree immediately, load inventories in background for
+  // scan-total estimation. Tree uses Directory.listSync() so it doesn't wait.
+  Future<void> _advanceToFilter() async {
+    setState(() {
+      _step = _Step.filter;
+      _inventories = {};
+      _excludedPaths.clear();
+      _excludedExtensions.clear();
+      _errorMessage = null;
+    });
+    // Load inventories in background — not needed for tree display, only for
+    // the scan progress denominator computed in _startScan().
+    final results = <String, InventoryResult?>{};
+    for (final folder in _folders) {
+      try {
+        results[folder] = await _manifestService.buildInventory(folder);
+      } catch (_) {
+        results[folder] = null;
+      }
+    }
+    if (mounted) setState(() => _inventories = results);
+  }
 
   // Step 1 → 2
   void _advanceToScope() => setState(() => _step = _Step.scope);
@@ -229,8 +233,19 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
     });
     _startTimer();
 
-    // Quick pre-count (no hashing) to get a denominator for the progress bar.
-    final total = await _countFiles(_folders);
+    // Derive scan total from inventories (already loaded during Filter step).
+    // Subtract excluded extension counts for a more accurate estimate.
+    int total = 0;
+    for (final inv in _inventories.values) {
+      if (inv == null) continue;
+      int folderCount = inv.totalFiles;
+      for (final stat in inv.extensions) {
+        if (_excludedExtensions.contains(stat.extension)) {
+          folderCount -= stat.count;
+        }
+      }
+      total += folderCount.clamp(0, inv.totalFiles);
+    }
     if (mounted) setState(() => _scanTotal = total);
 
     // Scan hashes everything; exclusions are applied at build time (#121).
@@ -1264,6 +1279,7 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
       _targetParentPath = null;
       _targetNameController.clear();
       _targetManuallySet = false;
+      _inventories = {};
       _excludedPaths.clear();
       _excludedExtensions.clear();
       _scanTotal = 0;

--- a/lib/consolidate_screen.dart
+++ b/lib/consolidate_screen.dart
@@ -633,6 +633,98 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
   // Step 2 — Filter (two-panel tree view)
   // ---------------------------------------------------------------------------
 
+  /// Compact extension summary strip — one tappable pill per file type,
+  /// sorted by count descending. Tap to toggle exclusion of that type.
+  Widget _buildExtensionStrip() {
+    // Merge extension counts across all inventories.
+    final merged = <String, int>{};
+    for (final inv in _inventories.values) {
+      if (inv == null) continue;
+      for (final stat in inv.extensions) {
+        merged[stat.extension] = (merged[stat.extension] ?? 0) + stat.count;
+      }
+    }
+
+    if (merged.isEmpty) {
+      // Inventories still loading — show a subtle placeholder.
+      return Container(
+        height: 36,
+        color: Colors.grey[50],
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        alignment: Alignment.centerLeft,
+        child: Text(
+          'Loading file types…',
+          style: TextStyle(fontSize: 11, color: Colors.grey[400]),
+        ),
+      );
+    }
+
+    final sorted = merged.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    return Container(
+      height: 36,
+      color: Colors.grey[50],
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        itemCount: sorted.length,
+        separatorBuilder: (context, i) => const SizedBox(width: 6),
+        itemBuilder: (context, i) {
+          final ext = sorted[i].key;
+          final count = sorted[i].value;
+          final excluded = _excludedExtensions.contains(ext);
+          final label = ext.isEmpty ? '(none)' : ext;
+          return GestureDetector(
+            onTap: () => setState(() {
+              if (excluded) {
+                _excludedExtensions.remove(ext);
+              } else {
+                _excludedExtensions.add(ext);
+              }
+            }),
+            child: Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+              decoration: BoxDecoration(
+                color: excluded ? Colors.grey[200] : const Color(0xFFE3F0FB),
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                  color: excluded
+                      ? Colors.grey[400]!
+                      : const Color(0xFF0E70C0),
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (excluded)
+                    Padding(
+                      padding: const EdgeInsets.only(right: 3),
+                      child: Icon(Icons.block,
+                          size: 10, color: Colors.grey[500]),
+                    ),
+                  Text(
+                    '$label  $count',
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: excluded
+                          ? Colors.grey[500]
+                          : const Color(0xFF0E70C0),
+                      decoration: excluded
+                          ? TextDecoration.lineThrough
+                          : null,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
   Widget _buildFilterStep() {
     final excludedCount = _excludedPaths.length + _excludedExtensions.length;
     return Column(
@@ -698,6 +790,10 @@ class _ConsolidateScreenState extends State<ConsolidateScreen> {
             ],
           ),
         ),
+        const Divider(height: 1),
+        // Extension summary strip — merged counts across all folders.
+        // Tapping an extension pill excludes/includes that whole type.
+        _buildExtensionStrip(),
         const Divider(height: 1),
         // Two-panel tree area
         Expanded(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: filesteward
 description: A macOS-first FileSteward prototype.
 publish_to: 'none'
-version: 0.6.1+1
+version: 0.6.2+1
 
 environment:
   sdk: ^3.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: filesteward
 description: A macOS-first FileSteward prototype.
 publish_to: 'none'
-version: 0.6.4+1
+version: 0.6.5+1
 
 environment:
   sdk: ^3.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: filesteward
 description: A macOS-first FileSteward prototype.
 publish_to: 'none'
-version: 0.6.5+1
+version: 0.6.6+1
 
 environment:
   sdk: ^3.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: filesteward
 description: A macOS-first FileSteward prototype.
 publish_to: 'none'
-version: 0.6.3+1
+version: 0.6.4+1
 
 environment:
   sdk: ^3.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: filesteward
 description: A macOS-first FileSteward prototype.
 publish_to: 'none'
-version: 0.6.6+1
+version: 0.6.7+1
 
 environment:
   sdk: ^3.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: filesteward
 description: A macOS-first FileSteward prototype.
 publish_to: 'none'
-version: 0.6.2+1
+version: 0.6.3+1
 
 environment:
   sdk: ^3.9.0

--- a/rust_core/src/consolidate.rs
+++ b/rust_core/src/consolidate.rs
@@ -1182,8 +1182,20 @@ fn handle_v2_build(cmd: V2BuildCmd) {
 
 /// Like [hash_all_files] but optionally filtered by file extensions.
 /// [extensions] entries must be lowercase with leading dot, e.g. [".jpg"].
-fn hash_all_files_ext(root: &Path, extensions: &[String]) -> Vec<(String, Option<String>, u64)> {
+/// Hash all files under `root`, optionally filtered by `extensions`.
+/// Emits a `consolidate_progress` event every `progress_interval` files so
+/// the Flutter UI can drive a determinate progress bar.
+/// `source` is the folder label; `base_count` is the number of files already
+/// hashed from previous folders (so the running total stays monotonic).
+fn hash_all_files_ext(
+    root: &Path,
+    extensions: &[String],
+    source: &str,
+    base_count: usize,
+    progress_interval: usize,
+) -> Vec<(String, Option<String>, u64)> {
     let files = walk_files(root);
+    let counter = AtomicUsize::new(0);
     files
         .par_iter()
         .filter(|p| {
@@ -1204,6 +1216,14 @@ fn hash_all_files_ext(root: &Path, extensions: &[String]) -> Vec<(String, Option
                 .strip_prefix(root)
                 .map(|r| r.to_string_lossy().to_string())
                 .unwrap_or_default();
+            let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
+            if n % progress_interval == 0 {
+                emit(&ConsolidateProgressEvent {
+                    event_type: "consolidate_progress",
+                    source: source.to_string(),
+                    files_scanned: base_count + n,
+                });
+            }
             (rel, hash, size)
         })
         .collect()
@@ -1230,13 +1250,19 @@ fn handle_unified_scan(cmd: UnifiedScanCmd) {
     });
 
     // Hash all files across all folders, tracking which folder each came from.
+    // Emit per-file progress every 100 files so the Flutter UI bar advances
+    // smoothly rather than jumping folder-by-folder.
     let mut all_entries: Vec<(String, String, Option<String>, u64)> = Vec::new();
     for folder in &cmd.folders {
         let folder_path = PathBuf::from(folder);
-        let folder_entries = hash_all_files_ext(&folder_path, &cmd.include_extensions);
+        let base = all_entries.len();
+        let folder_entries =
+            hash_all_files_ext(&folder_path, &cmd.include_extensions, folder, base, 100);
         for (rel, hash_opt, size) in folder_entries {
             all_entries.push((folder.clone(), rel, hash_opt, size));
         }
+        // Emit a final event for this folder so the count is always current
+        // after each folder completes (catches the remainder < 100).
         emit(&ConsolidateProgressEvent {
             event_type: "consolidate_progress",
             source: folder.clone(),


### PR DESCRIPTION
## Summary
Completes the Consolidate flow so it can be walked end-to-end for the first time.

- Step 2 becomes a lazy two-panel tree: source folders (left) + naive merged target with source-dot duplicate indicators (right)
- Step 5 becomes a lazy two-panel review: annotated source trees (left) + rationalized target with folder-level checkboxes (right)
- Folder/file exclusion via checkbox + right-click context menu ("Exclude", never "Delete")
- OS folder name mapping applied silently (macOS table)
- Folder-level decisions wired into Build command

## Issues
Closes #118, #119, #120, #121, #122

## Depends on
PR #117 (iter7-consolidate-ux) — base branch

## Review note
PR #117 and this PR will be reviewed and merged together — the full flow cannot be walked until both are in place.

## Test plan
- [ ] Step 2 left panel lazy-expands one level at a time
- [ ] Step 2 right panel shows merged target with colored source dots
- [ ] Unchecking a folder in Step 2 right panel excludes it from target
- [ ] Right-click "Exclude this file" / "Exclude all .ext" / "Exclude this folder" work on both panels
- [ ] Step 5 left panel shows source trees with duplicate/provenance annotations
- [ ] Step 5 right panel shows rationalized target with folder checkboxes
- [ ] Unchecked folders in Step 5 are absent from the Build output
- [ ] OS folder name mapping applied silently (My Pictures → Pictures etc.)
- [ ] Walk the full 7-step flow end-to-end on real backup folders

🤖 Generated with [Claude Code](https://claude.com/claude-code)